### PR TITLE
feat: add HTTP response chaos rules

### DIFF
--- a/.changeset/calm-chaos-rules.md
+++ b/.changeset/calm-chaos-rules.md
@@ -1,0 +1,7 @@
+---
+"@counterfact/runtime": patch
+"@counterfact/repl": patch
+"counterfact": patch
+---
+
+Add shared HTTP-response chaos rules that can be controlled from the live REPL.

--- a/packages/counterfact/docs/features/repl.md
+++ b/packages/counterfact/docs/features/repl.md
@@ -90,6 +90,27 @@ await req.send();
 
 See the [Route Builder guide](./route-builder.md) for full documentation.
 
+## HTTP response faults with `chaos()`
+
+Create temporary response-layer faults without editing a handler or restarting
+the server:
+
+```js
+// Fail the next three matching requests.
+chaos("/payments").next(3).status(503).header("Retry-After", "1");
+
+// Apply indefinitely, but fire for about 20% of matching requests.
+const intermittent = chaos("/payments").probability(0.2).status(500);
+
+intermittent.stop();
+intermittent.start();
+```
+
+A rule applies indefinitely unless `next(...)` bounds it. In multi-API mode,
+the unqualified `chaos()` global controls the shared HTTP layer and therefore
+applies to matching routes in every API group. It simulates HTTP responses, not
+network disconnects. See the [Chaos API reference](../reference.md#chaos-api-http-layer-fault-injection).
+
 ## Scenario scripts with `.scenario`
 
 For more complex setups you can automate REPL interactions by writing _scenario scripts_ — plain TypeScript files that export named functions. Run them with `.scenario`:

--- a/packages/counterfact/docs/patterns/index.md
+++ b/packages/counterfact/docs/patterns/index.md
@@ -4,32 +4,33 @@ These playbooks show how people use Counterfact in real development and test wor
 
 Most projects start with [Explore a New API](./explore-new-api.md) or [Executable Spec](./executable-spec.md) to get a running server from an OpenAPI spec with no code. From there, [Mock APIs with Dummy Data](./mock-with-dummy-data.md) and [AI-Assisted Implementation](./ai-assisted-implementation.md) are the natural next steps for adding useful responses — the former by hand, the latter with an AI agent doing the heavy lifting. [Model the Workflow, Not the Backend](./model-the-workflow.md) sets the boundary for both: prefer deterministic handlers and add only the state that a supported client workflow can observe.
 
-As the mock grows, [Scenario Scripts](./scenario-scripts.md) let you automate repetitive REPL interactions — seeding data on startup, building reusable request sequences — while [Federated Context Files](./federated-context.md), [Share State Across API Groups](./shared-store.md), and [Test the Context, Not the Handlers](./test-context-not-handlers.md) keep stateful logic organized and reliable. [Live Server Inspection with the REPL](./repl-inspection.md) is Counterfact's most distinctive feature, letting you seed data, send requests, and toggle behavior in real time without restarting, and [Simulate Failures and Edge Cases](./simulate-failures.md) and [Simulate Realistic Latency](./simulate-latency.md) extend any mock to cover the error paths and performance characteristics that real services exhibit.
+As the mock grows, [Scenario Scripts](./scenario-scripts.md) let you automate repetitive interactions — seeding data on startup, building reusable request sequences — while [Federated Context Files](./federated-context.md), [Share State Across API Groups](./shared-store.md), and [Test the Context, Not the Handlers](./test-context-not-handlers.md) keep stateful logic organized and reliable. [Live Server Inspection with the REPL](./repl-inspection.md) is Counterfact's most distinctive feature, letting you seed data, send requests, and toggle behavior in real time without restarting, and [Simulate Failures and Edge Cases](./simulate-failures.md), [Test Fault Scenarios with Chaos Rules](./test-fault-scenarios-with-chaos.md), and [Simulate Realistic Latency](./simulate-latency.md) extend any mock to cover the error paths and performance characteristics that real services exhibit.
 
 When your project involves multiple versions or multiple specs, [Multiple API Versions](./multiple-versions.md) shows how to serve them from a shared set of route files using `$.minVersion()` to branch on version without duplicating handlers. For teams that want the mock to remain a reliable, long-lived artifact, [Reference Implementation](./reference-implementation.md) and [Automated Integration Tests](./automated-integration-tests.md) make it a first-class part of the codebase that can run in CI. Finally, [Agentic Sandbox](./agentic-sandbox.md) and [Hybrid Proxy](./hybrid-proxy.md) address the two common integration strategies — isolating an AI agent from the real service, or blending mock and live traffic — and [Custom Middleware](./custom-middleware.md) covers cross-cutting concerns like authentication and logging without touching individual handlers.
 
 ## Find your path
 
-| Pattern                                                              | When to use it                                                                                       |
-| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [Explore a New API](./explore-new-api.md)                            | You have a spec but no running backend or production access                                          |
-| [Executable Spec](./executable-spec.md)                              | You want immediate feedback on how spec changes affect the running server during API design          |
-| [Mock APIs with Dummy Data](./mock-with-dummy-data.md)               | You need realistic-looking responses to build a UI, run a demo, or write assertions                  |
-| [Model the Workflow, Not the Backend](./model-the-workflow.md)       | A workflow needs shared state, but the simulator should remain small and deterministic               |
-| [Scenario Scripts](./scenario-scripts.md)                            | You want to automate REPL interactions, seed data on startup, or build reusable state configurations |
-| [AI-Assisted Implementation](./ai-assisted-implementation.md)        | You want an AI agent to replace random responses with working handler logic                          |
-| [Federated Context Files](./federated-context.md)                    | You want each domain to own its state, with explicit cross-domain dependencies                       |
-| [Share State Across API Groups](./shared-store.md)                   | Several API groups model one product and need shared domain data or invariants                       |
-| [Test the Context, Not the Handlers](./test-context-not-handlers.md) | You want to keep shared stateful logic reliable as the mock grows                                    |
-| [Live Server Inspection with the REPL](./repl-inspection.md)         | You want to seed data, send requests, and toggle behavior without restarting the server              |
-| [Simulate Failures and Edge Cases](./simulate-failures.md)           | You need reproducible, on-demand error conditions for development or testing                         |
-| [Simulate Realistic Latency](./simulate-latency.md)                  | You want to test how clients and UIs behave under realistic response times                           |
-| [Reference Implementation](./reference-implementation.md)            | You want a working, executable implementation that expresses intended API behavior in code           |
-| [Multiple API Versions](./multiple-versions.md)                      | You maintain multiple versions of an API and want shared handlers that adapt by version              |
-| [Agentic Sandbox](./agentic-sandbox.md)                              | You are building an AI coding agent and want to avoid rate limits and costs during development       |
-| [Hybrid Proxy](./hybrid-proxy.md)                                    | Some endpoints exist in the real backend; others need to be mocked                                   |
-| [Automated Integration Tests](./automated-integration-tests.md)      | You want to run real HTTP tests against the mock in a CI-friendly test suite                         |
-| [Custom Middleware](./custom-middleware.md)                          | You want authentication, headers, or logging applied uniformly across a group of routes              |
+| Pattern                                                                       | When to use it                                                                                       |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Explore a New API](./explore-new-api.md)                                     | You have a spec but no running backend or production access                                          |
+| [Executable Spec](./executable-spec.md)                                       | You want immediate feedback on how spec changes affect the running server during API design          |
+| [Mock APIs with Dummy Data](./mock-with-dummy-data.md)                        | You need realistic-looking responses to build a UI, run a demo, or write assertions                  |
+| [Model the Workflow, Not the Backend](./model-the-workflow.md)                | A workflow needs shared state, but the simulator should remain small and deterministic               |
+| [Scenario Scripts](./scenario-scripts.md)                                     | You want to automate REPL interactions, seed data on startup, or build reusable state configurations |
+| [AI-Assisted Implementation](./ai-assisted-implementation.md)                 | You want an AI agent to replace random responses with working handler logic                          |
+| [Federated Context Files](./federated-context.md)                             | You want each domain to own its state, with explicit cross-domain dependencies                       |
+| [Share State Across API Groups](./shared-store.md)                            | Several API groups model one product and need shared domain data or invariants                       |
+| [Test the Context, Not the Handlers](./test-context-not-handlers.md)          | You want to keep shared stateful logic reliable as the mock grows                                    |
+| [Live Server Inspection with the REPL](./repl-inspection.md)                  | You want to seed data, send requests, and toggle behavior without restarting the server              |
+| [Simulate Failures and Edge Cases](./simulate-failures.md)                    | You need reproducible, on-demand error conditions for development or testing                         |
+| [Test Fault Scenarios with Chaos Rules](./test-fault-scenarios-with-chaos.md) | You want to inject HTTP-layer failures from the REPL without editing handlers                        |
+| [Simulate Realistic Latency](./simulate-latency.md)                           | You want to test how clients and UIs behave under realistic response times                           |
+| [Reference Implementation](./reference-implementation.md)                     | You want a working, executable implementation that expresses intended API behavior in code           |
+| [Multiple API Versions](./multiple-versions.md)                               | You maintain multiple versions of an API and want shared handlers that adapt by version              |
+| [Agentic Sandbox](./agentic-sandbox.md)                                       | You are building an AI coding agent and want to avoid rate limits and costs during development       |
+| [Hybrid Proxy](./hybrid-proxy.md)                                             | Some endpoints exist in the real backend; others need to be mocked                                   |
+| [Automated Integration Tests](./automated-integration-tests.md)               | You want to run real HTTP tests against the mock in a CI-friendly test suite                         |
+| [Custom Middleware](./custom-middleware.md)                                   | You want authentication, headers, or logging applied uniformly across a group of routes              |
 
 ## See also
 

--- a/packages/counterfact/docs/patterns/test-fault-scenarios-with-chaos.md
+++ b/packages/counterfact/docs/patterns/test-fault-scenarios-with-chaos.md
@@ -1,0 +1,44 @@
+# Test Fault Scenarios with Chaos Rules
+
+Use the Live REPL to test how a client behaves under upstream failures without
+changing route handlers or restarting Counterfact.
+
+## Problem
+
+Reproducing a 5xx response, a bounded outage, or intermittent failures often
+requires temporary handler code. That mixes fault controls into the healthy
+simulation and makes exploratory tests harder to repeat.
+
+## Solution
+
+Add an HTTP-response rule with `chaos()` while the simulator is running:
+
+```ts
+const intermittent = chaos("/payments")
+  .probability(0.2)
+  .status(503)
+  .header("Retry-After", "1");
+
+const outage = chaos("/payments").next(3).status(503);
+
+intermittent.stop();
+outage.stop();
+```
+
+Rules are active indefinitely by default. `next(...)` bounds a rule, and a
+probability-skipped request does not consume its remaining count. In a
+multi-API simulator, one REPL rule applies to matching routes across every API
+group.
+
+## Consequences
+
+- Healthy route code stays unchanged.
+- Rules can alter status, delay, headers, or body at the HTTP response layer.
+- `Content-Type` stays under Counterfact's serialization control.
+- This does not simulate network disconnects or transport-level timeouts.
+
+## Related patterns
+
+- [Simulate Failures and Edge Cases](./simulate-failures.md)
+- [Simulate Realistic Latency](./simulate-latency.md)
+- [Live Server Inspection with the REPL](./repl-inspection.md)

--- a/packages/counterfact/docs/reference.md
+++ b/packages/counterfact/docs/reference.md
@@ -17,6 +17,7 @@ Complete reference for Counterfact's architecture, route handlers, and CLI.
 - [Hybrid proxy](#hybrid-proxy)
 - [Middleware](#middleware)
 - [Type safety](#type-safety)
+- [Chaos API (HTTP-layer fault injection)](#chaos-api-http-layer-fault-injection)
 - [Programmatic API](#programmatic-api)
 - [Multiple API versions](#multiple-api-versions)
 - [CLI reference](#cli-reference)
@@ -329,6 +330,45 @@ export const GET: HTTP_GET = ($) => {
 ```
 
 OpenAPI descriptions are preserved as JSDoc comments on generated types, so they appear inline in your editor as you type.
+
+---
+
+## Chaos API (HTTP-layer fault injection)
+
+The Live REPL exposes `chaos(pathPrefix?)` for changing simulated HTTP
+responses without editing route handlers. The registry is shared by every API
+group in one Counterfact simulator.
+
+```ts
+const fault = chaos("/orders")
+  .next(3)
+  .probability(0.5)
+  .status(503)
+  .delay(1_000)
+  .header("Retry-After", "1")
+  .transformBody((body) => ({ body, degraded: true }));
+
+fault.stop();
+fault.start();
+```
+
+`chaos()` with no prefix matches every request. A new rule is active
+indefinitely; use `next()` or `next(count)` to bound how many successful rule
+applications it consumes. A stopped rule or a request skipped by
+`probability(...)` does not consume that count. Probability must be a finite
+number from `0` through `1`, otherwise Counterfact throws a `RangeError`.
+
+Available mutations are `status(code)`, `delay(ms)`, `header(name, value)`,
+`removeHeader(name)`, `body(value)`, and `transformBody(fn)`. Header names are
+matched case-insensitively and the last mutation for a header wins.
+`Content-Type` is protected because Counterfact owns response serialization.
+Likewise, the last call to `body()` or `transformBody()` wins.
+
+When several active rules match, exactly one applies: the longest path prefix
+wins, then the most recently configured rule. There is no `always()` method
+because indefinite application is already the default, and no `timeout()`
+method because chaos rules model HTTP responses rather than network
+disconnects.
 
 ---
 

--- a/packages/counterfact/src/api-runner.ts
+++ b/packages/counterfact/src/api-runner.ts
@@ -6,6 +6,7 @@ import {
   ScenarioFileGenerator,
 } from "@counterfact/generator";
 import {
+  ChaosRegistry,
   ContextRegistry,
   Dispatcher,
   loadOpenApiDocument,
@@ -124,6 +125,7 @@ export class ApiRunner {
     version = "",
     versions: readonly string[] = [],
     groupState?: ApiRunnerGroupState,
+    chaosRegistry = new ChaosRegistry(),
   ) {
     this.group = group;
     this.version = version;
@@ -168,6 +170,7 @@ export class ApiRunner {
       config,
       version,
       versions,
+      chaosRegistry,
     );
 
     this.transpiler = new Transpiler(
@@ -206,6 +209,7 @@ export class ApiRunner {
     version = "",
     versions: readonly string[] = [],
     groupState?: ApiRunnerGroupState,
+    chaosRegistry = new ChaosRegistry(),
   ): Promise<ApiRunner> {
     const nativeTs = await runtimeCanExecuteErasableTs();
 
@@ -238,6 +242,7 @@ export class ApiRunner {
       version,
       versions,
       groupState,
+      chaosRegistry,
     );
   }
 

--- a/packages/counterfact/src/app.ts
+++ b/packages/counterfact/src/app.ts
@@ -9,6 +9,7 @@ import {
 } from "@counterfact/client";
 import { generateVersionsTsContent, Repository } from "@counterfact/generator";
 import {
+  ChaosRegistry,
   ContextRegistry,
   ScenarioRegistry,
   StoreLoader,
@@ -280,6 +281,7 @@ export async function counterfact<TStore = unknown>(
   });
   const initialStore = await storeLoader.load();
   hasStore = initialStore !== undefined;
+  const chaosRegistry = new ChaosRegistry();
 
   // Compute the ordered versions per group (oldest first, as declared in specs).
   // This list is passed to each runner so that $.minVersion() can compare
@@ -331,6 +333,7 @@ export async function counterfact<TStore = unknown>(
         spec.version ?? "",
         versionsByGroup.get(spec.group) ?? [],
         stateByGroup.get(spec.group),
+        chaosRegistry,
       ),
     ),
   );
@@ -513,6 +516,7 @@ export async function counterfact<TStore = unknown>(
         ({ command }) => {
           sendTelemetry("repl_command_used", { command });
         },
+        chaosRegistry,
       );
       replServers.add(replServer);
       return replServer;

--- a/packages/counterfact/test/api-runner.test.ts
+++ b/packages/counterfact/test/api-runner.test.ts
@@ -3,6 +3,7 @@ import { usingTemporaryFiles } from "using-temporary-files";
 import { ApiRunner } from "../src/api-runner.js";
 import { CodeGenerator, ScenarioFileGenerator } from "@counterfact/generator";
 import {
+  ChaosRegistry,
   ContextRegistry,
   Dispatcher,
   ModuleLoader,
@@ -100,6 +101,22 @@ describe("ApiRunner", () => {
           basePath: $.path("."),
         });
         expect(runner.dispatcher).toBeInstanceOf(Dispatcher);
+      });
+    });
+
+    it("passes a supplied chaos registry to the dispatcher", async () => {
+      await usingTemporaryFiles(async ($) => {
+        const chaosRegistry = new ChaosRegistry();
+        const runner = await ApiRunner.create(
+          { ...baseConfig, basePath: $.path(".") },
+          "",
+          "",
+          [],
+          undefined,
+          chaosRegistry,
+        );
+
+        expect(runner.dispatcher.chaosRegistry).toBe(chaosRegistry);
       });
     });
 

--- a/packages/counterfact/test/app.test.ts
+++ b/packages/counterfact/test/app.test.ts
@@ -7,6 +7,7 @@ import { usingTemporaryFiles } from "using-temporary-files";
 import * as app from "../src/app";
 import { ApiRunner } from "../src/api-runner";
 import {
+  ChaosRegistry,
   ContextRegistry,
   ScenarioRegistry,
   StoreLoader,
@@ -341,6 +342,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ openApiPath: "_", prefix: "/api/v2" }),
@@ -351,9 +353,54 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
+    expect(spy.mock.calls[0]?.[5]).toBe(spy.mock.calls[1]?.[5]);
 
     spy.mockRestore();
+  });
+
+  it("applies a REPL chaos rule across every API group", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "billing/routes/hello.js",
+        'export function GET() { return { body: "billing" }; }',
+      );
+      await $.add(
+        "inventory/routes/hello.js",
+        'export function GET() { return { body: "inventory" }; }',
+      );
+
+      const simulator = await app.counterfact(
+        { ...mockConfig, basePath: $.path("."), port: 0 },
+        [
+          { source: "_", prefix: "/billing", group: "billing" },
+          { source: "_", prefix: "/inventory", group: "inventory" },
+        ],
+      );
+      const { stop } = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+      const replServer = simulator.startRepl();
+
+      try {
+        (replServer.context as any).chaos().status(503);
+
+        const billing = await request(simulator.koaApp.callback()).get(
+          "/billing/hello",
+        );
+        const inventory = await request(simulator.koaApp.callback()).get(
+          "/inventory/hello",
+        );
+
+        expect(billing.status).toBe(503);
+        expect(inventory.status).toBe(503);
+      } finally {
+        replServer.close();
+        await stop();
+      }
+    });
   });
 
   it("throws when multiple specs include an empty group", async () => {
@@ -568,6 +615,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ prefix: "" }),
@@ -578,6 +626,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
 
     spy.mockRestore();
@@ -601,6 +650,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
 
     spy.mockRestore();
@@ -622,6 +672,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
 
     spy.mockRestore();
@@ -643,6 +694,7 @@ describe("counterfact", () => {
         contextRegistry: expect.any(ContextRegistry),
         scenarioRegistry: expect.any(ScenarioRegistry),
       }),
+      expect.any(ChaosRegistry),
     );
 
     spy.mockRestore();

--- a/packages/repl/README.md
+++ b/packages/repl/README.md
@@ -9,6 +9,7 @@ experience without importing Counterfact's CLI or telemetry policy.
 ```js
 import { createOpenApiRouteCatalog } from "@counterfact/client";
 import {
+  ChaosRegistry,
   ContextRegistry,
   Registry,
   ScenarioRegistry,
@@ -18,6 +19,7 @@ import { startRepl } from "@counterfact/repl";
 const contextRegistry = new ContextRegistry();
 const registry = new Registry();
 const scenarioRegistry = new ScenarioRegistry();
+const chaosRegistry = new ChaosRegistry();
 const config = { port: 3000, proxyPaths: new Map(), proxyUrl: "" };
 const routeCatalog = createOpenApiRouteCatalog({ paths: {} });
 
@@ -31,6 +33,7 @@ const replServer = startRepl(
   undefined,
   undefined,
   (event) => console.log(event),
+  chaosRegistry,
 );
 ```
 
@@ -48,10 +51,15 @@ The REPL starts with these live values:
 - `route(path)` creates an immutable request builder.
 - `routes` is shared with scenario functions.
 - `store` is present when the simulator has a shared store.
+- `chaos(pathPrefix?)` creates a fluent HTTP-response fault rule when the
+  embedding application supplies a `ChaosRegistry`.
 
 For multiple APIs, `context`, `loadContext`, `route`, and `routes` are grouped
 by API name. The `.proxy` command changes live proxy configuration and
 `.scenario` applies named scenario functions.
+
+The application should pass the same chaos registry to every runtime
+dispatcher and the REPL so one interactive rule applies across all API groups.
 
 See [`examples/complete-routes.mjs`](./examples/complete-routes.mjs) for a
 complete public-import example.

--- a/packages/repl/src/repl.ts
+++ b/packages/repl/src/repl.ts
@@ -6,6 +6,7 @@ import {
   type RouteCatalog,
 } from "@counterfact/client";
 import type {
+  ChaosRegistry,
   ContextLookup,
   RouteListing,
   ScenarioCatalog,
@@ -258,6 +259,7 @@ export function createCompleter(
  * - `context` / `loadContext(path)` globals wired to the {@link ContextRegistry}.
  * - `client` — a {@link RawHttpClient} pre-configured for `localhost`.
  * - `route(path)` — creates a {@link RouteBuilder} for the given path.
+ * - `chaos(pathPrefix?)` — creates an HTTP-response fault rule when configured.
  * - `.counterfact` — help command.
  * - `.proxy` — proxy configuration command.
  * - `.scenario` — runs a named scenario function from the scenarios directory.
@@ -269,6 +271,7 @@ export function createCompleter(
  * @param routeCatalog - Optional route catalog for tab completion and request help.
  * @param scenarioRegistry - Optional scenario registry for `.scenario` support.
  * @param reportEvent - Optional observer for REPL command usage.
+ * @param chaosRegistry - Optional server-owned registry exposed as the `chaos()` global.
  * @returns The configured Node.js REPL server instance.
  */
 export function startRepl(
@@ -281,6 +284,7 @@ export function startRepl(
   apiBindings?: ReplApiBinding[],
   store?: object,
   reportEvent?: ReplEventReporter,
+  chaosRegistry?: ChaosRegistry,
 ) {
   const bindings =
     apiBindings === undefined || apiBindings.length === 0
@@ -451,6 +455,11 @@ export function startRepl(
       print(
         "- route('/some/path'): create a request builder for the given path",
       );
+      if (chaosRegistry !== undefined) {
+        print(
+          "- chaos('/some/path'): create an HTTP-response fault rule for a path prefix",
+        );
+      }
       print("");
       print(
         "For more information, see https://github.com/counterfact/api-simulator/blob/main/docs/usage.md",
@@ -513,6 +522,11 @@ export function startRepl(
 
   if (store !== undefined) {
     replServer.context.store = store;
+  }
+
+  if (chaosRegistry !== undefined) {
+    replServer.context.chaos = (pathPrefix = "") =>
+      chaosRegistry.createRule(pathPrefix);
   }
 
   replServer.defineCommand("scenario", {

--- a/packages/repl/test/repl.test.ts
+++ b/packages/repl/test/repl.test.ts
@@ -4,6 +4,7 @@ import { afterEach, jest } from "@jest/globals";
 
 import { createOpenApiRouteCatalog } from "@counterfact/client";
 import {
+  ChaosRegistry,
   ContextRegistry,
   Registry,
   ScenarioRegistry,
@@ -61,6 +62,7 @@ class ReplHarness {
     apiBindings?: ReplApiBinding[],
     store?: object,
     reportEvent?: ReplEventReporter,
+    chaosRegistry?: ChaosRegistry,
   ) {
     this.server = startRepl(
       contextRegistry,
@@ -72,6 +74,7 @@ class ReplHarness {
       apiBindings,
       store,
       reportEvent,
+      chaosRegistry,
     );
   }
 
@@ -96,6 +99,7 @@ function createHarness(
   apiBindings?: ReplApiBinding[],
   store?: object,
   reportEvent?: ReplEventReporter,
+  chaosRegistry?: ChaosRegistry,
 ) {
   const contextRegistry = new ContextRegistry();
   const registry = new Registry();
@@ -111,6 +115,7 @@ function createHarness(
     apiBindings,
     store,
     reportEvent,
+    chaosRegistry,
   );
 
   openServers.push(harness.server);
@@ -129,6 +134,38 @@ afterEach(() => {
 });
 
 describe("REPL", () => {
+  it("does not expose chaos without a server-owned registry", () => {
+    const { harness } = createHarness();
+
+    expect(harness.server.context.chaos).toBeUndefined();
+  });
+
+  it("exposes a supplied registry as the chaos global", () => {
+    const chaosRegistry = new ChaosRegistry();
+    const { harness } = createHarness(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      chaosRegistry,
+    );
+    const chaos = harness.server.context.chaos as (
+      prefix?: string,
+    ) => ReturnType<ChaosRegistry["createRule"]>;
+
+    const globalRule = chaos().status(503);
+    const scopedRule = chaos("/orders").next(2).status(429);
+
+    expect(globalRule.prefix).toBe("");
+    expect(scopedRule.prefix).toBe("/orders");
+    expect(chaosRegistry.findBestMatch("/orders/1")).toBe(scopedRule);
+
+    harness.call("counterfact", "");
+    expect(harness.output).toContain(
+      "- chaos('/some/path'): create an HTTP-response fault rule for a path prefix",
+    );
+  });
+
   it("turns on the proxy globally", () => {
     const { config, harness } = createHarness();
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -9,3 +9,23 @@ Koa adapter from `@counterfact/runtime/koa`, and the MSW adapter from
 
 See [`examples/registries.mjs`](./examples/registries.mjs) for a complete
 public-import example.
+
+## HTTP response fault injection
+
+`ChaosRegistry` owns fluent rules that can alter a dispatcher's status, delay,
+headers, or body after normal response processing:
+
+```js
+import { ChaosRegistry } from "@counterfact/runtime";
+
+const chaosRegistry = new ChaosRegistry();
+chaosRegistry
+  .createRule("/orders")
+  .next(3)
+  .probability(0.5)
+  .status(503)
+  .header("Retry-After", "1");
+```
+
+Rules apply indefinitely by default. `Content-Type` cannot be changed or
+removed by a chaos rule.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,10 @@
 export { ContextRegistry, type Context } from "./server/context-registry.js";
 export {
+  type ChaosApplyResult,
+  ChaosRegistry,
+  ChaosRule,
+} from "./server/chaos.js";
+export {
   Dispatcher,
   type DispatcherRequest,
   type OpenApiDocument as DispatcherOpenApiDocument,

--- a/packages/runtime/src/server/chaos.ts
+++ b/packages/runtime/src/server/chaos.ts
@@ -1,0 +1,201 @@
+import type { CounterfactResponseObject } from "./registry.js";
+
+const UNSET = Symbol("UNSET");
+const CONTENT_TYPE_HEADER = "content-type";
+
+let sequence = 0;
+
+type HeaderMutation =
+  { kind: "remove" } | { kind: "set"; name: string; value: string };
+
+export interface ChaosApplyResult {
+  delayMs?: number;
+  response: CounterfactResponseObject;
+}
+
+/** A fluent HTTP-response fault rule for requests matching a path prefix. */
+export class ChaosRule {
+  public readonly prefix: string;
+
+  private remaining: number | "indefinite" = "indefinite";
+  private firingProbability = 1;
+  private statusCode?: number;
+  private delayMilliseconds?: number;
+  private readonly headerMutations = new Map<string, HeaderMutation>();
+  private replacementBody: symbol | unknown = UNSET;
+  private bodyTransformer?: (body: unknown) => unknown;
+  private active = true;
+  private revision = ++sequence;
+
+  public constructor(prefix: string) {
+    this.prefix = prefix;
+  }
+
+  public get updatedAt(): number {
+    return this.revision;
+  }
+
+  public get isEligible(): boolean {
+    return (
+      this.active && (this.remaining === "indefinite" || this.remaining > 0)
+    );
+  }
+
+  private touch(): void {
+    this.revision = ++sequence;
+  }
+
+  public next(count = 1): this {
+    this.remaining = count;
+    this.touch();
+    return this;
+  }
+
+  public probability(value: number): this {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new RangeError(
+        `Chaos rule probability must be a number between 0 and 1. Received: ${String(value)}`,
+      );
+    }
+
+    this.firingProbability = value;
+    this.touch();
+    return this;
+  }
+
+  public status(code: number): this {
+    this.statusCode = code;
+    this.touch();
+    return this;
+  }
+
+  public delay(ms: number): this {
+    this.delayMilliseconds = ms;
+    this.touch();
+    return this;
+  }
+
+  public header(name: string, value: string): this {
+    const normalizedName = name.toLowerCase();
+
+    if (normalizedName === CONTENT_TYPE_HEADER) return this;
+
+    this.headerMutations.set(normalizedName, { kind: "set", name, value });
+    this.touch();
+    return this;
+  }
+
+  public removeHeader(name: string): this {
+    const normalizedName = name.toLowerCase();
+
+    if (normalizedName === CONTENT_TYPE_HEADER) return this;
+
+    this.headerMutations.set(normalizedName, { kind: "remove" });
+    this.touch();
+    return this;
+  }
+
+  public body(value: unknown): this {
+    this.replacementBody = value;
+    this.bodyTransformer = undefined;
+    this.touch();
+    return this;
+  }
+
+  public transformBody(transform: (body: unknown) => unknown): this {
+    this.bodyTransformer = transform;
+    this.replacementBody = UNSET;
+    this.touch();
+    return this;
+  }
+
+  public stop(): this {
+    this.active = false;
+    this.touch();
+    return this;
+  }
+
+  public start(): this {
+    this.active = true;
+    this.touch();
+    return this;
+  }
+
+  public tryApply(
+    response: CounterfactResponseObject,
+  ): ChaosApplyResult | null {
+    if (!this.isEligible || Math.random() >= this.firingProbability) {
+      return null;
+    }
+
+    if (this.remaining !== "indefinite") {
+      this.remaining -= 1;
+    }
+
+    const headers: NonNullable<CounterfactResponseObject["headers"]> = {
+      ...(response.headers ?? {}),
+    };
+
+    for (const [normalizedName, mutation] of this.headerMutations) {
+      for (const existingName of Object.keys(headers)) {
+        if (existingName.toLowerCase() === normalizedName) {
+          // eslint-disable-next-line security/detect-object-injection -- existingName came from Object.keys(headers).
+          delete headers[existingName];
+        }
+      }
+
+      if (mutation.kind === "set") {
+        headers[mutation.name] = mutation.value;
+      }
+    }
+
+    let body: unknown = response.body;
+
+    if (this.replacementBody !== UNSET) {
+      body = this.replacementBody;
+    } else if (this.bodyTransformer !== undefined) {
+      body = this.bodyTransformer(body);
+    }
+
+    const result: CounterfactResponseObject = {
+      ...response,
+      body: body as CounterfactResponseObject["body"],
+      headers,
+    };
+
+    if (this.statusCode !== undefined) {
+      result.status = this.statusCode;
+    }
+
+    return { delayMs: this.delayMilliseconds, response: result };
+  }
+}
+
+/** Selects the most specific, most recently updated eligible chaos rule. */
+export class ChaosRegistry {
+  private readonly rules: ChaosRule[] = [];
+
+  public createRule(prefix = ""): ChaosRule {
+    const rule = new ChaosRule(prefix);
+    this.rules.push(rule);
+    return rule;
+  }
+
+  public findBestMatch(path: string): ChaosRule | undefined {
+    const eligible = this.rules.filter(
+      (rule) => rule.isEligible && path.startsWith(rule.prefix),
+    );
+
+    return eligible.reduce<ChaosRule | undefined>((best, rule) => {
+      if (best === undefined) return rule;
+      if (rule.prefix.length > best.prefix.length) return rule;
+      if (
+        rule.prefix.length === best.prefix.length &&
+        rule.updatedAt > best.updatedAt
+      ) {
+        return rule;
+      }
+      return best;
+    }, undefined);
+  }
+}

--- a/packages/runtime/src/server/chaos.ts
+++ b/packages/runtime/src/server/chaos.ts
@@ -70,6 +70,12 @@ export class ChaosRule {
   }
 
   public status(code: number): this {
+    if (!Number.isInteger(code) || code < 100 || code > 599) {
+      throw new RangeError(
+        `Chaos rule status must be an integer between 100 and 599. Received: ${String(code)}`,
+      );
+    }
+
     this.statusCode = code;
     this.touch();
     return this;

--- a/packages/runtime/src/server/chaos.ts
+++ b/packages/runtime/src/server/chaos.ts
@@ -46,6 +46,12 @@ export class ChaosRule {
   }
 
   public next(count = 1): this {
+    if (!Number.isInteger(count) || count < 0) {
+      throw new RangeError(
+        `Chaos rule count must be a non-negative integer. Received: ${String(count)}`,
+      );
+    }
+
     this.remaining = count;
     this.touch();
     return this;

--- a/packages/runtime/src/server/chaos.ts
+++ b/packages/runtime/src/server/chaos.ts
@@ -82,6 +82,12 @@ export class ChaosRule {
   }
 
   public delay(ms: number): this {
+    if (!Number.isFinite(ms) || ms < 0) {
+      throw new RangeError(
+        `Chaos rule delay must be a finite, non-negative number. Received: ${String(ms)}`,
+      );
+    }
+
     this.delayMilliseconds = ms;
     this.touch();
     return this;

--- a/packages/runtime/src/server/dispatcher.ts
+++ b/packages/runtime/src/server/dispatcher.ts
@@ -3,6 +3,7 @@ import createDebugger from "debug";
 
 import fetch, { Headers } from "node-fetch";
 
+import type { ChaosRegistry } from "./chaos.js";
 import type { ContextRegistry } from "./context-registry.js";
 import type {
   HttpMethods,
@@ -202,6 +203,8 @@ export class Dispatcher {
 
   public config?: DispatcherConfig;
 
+  public chaosRegistry?: ChaosRegistry;
+
   /**
    * The version label for this dispatcher's spec (e.g. `"v1"`, `"v2"`).
    * Empty string when running without a version.
@@ -223,6 +226,7 @@ export class Dispatcher {
     config?: DispatcherConfig,
     version = "",
     versions: readonly string[] = [],
+    chaosRegistry?: ChaosRegistry,
   ) {
     this.registry = registry;
     this.contextRegistry = contextRegistry;
@@ -231,6 +235,7 @@ export class Dispatcher {
     this.config = config;
     this.version = version;
     this.versions = versions;
+    this.chaosRegistry = chaosRegistry;
   }
 
   private parameterTypes(
@@ -685,6 +690,19 @@ export class Dispatcher {
           ],
         };
       }
+    }
+
+    const chaosRule = this.chaosRegistry?.findBestMatch(path);
+    const chaosResult = chaosRule?.tryApply(normalizedResponse);
+
+    if (chaosResult !== undefined && chaosResult !== null) {
+      if (chaosResult.delayMs !== undefined && chaosResult.delayMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, chaosResult.delayMs);
+        });
+      }
+
+      return chaosResult.response;
     }
 
     return normalizedResponse;

--- a/packages/runtime/test/server/chaos.test.ts
+++ b/packages/runtime/test/server/chaos.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+import { ChaosRegistry, ChaosRule } from "../../src/server/chaos.js";
+import { ContextRegistry } from "../../src/server/context-registry.js";
+import { Dispatcher } from "../../src/server/dispatcher.js";
+import { Registry } from "../../src/server/registry.js";
+
+function makeDispatcher(chaosRegistry: ChaosRegistry): Dispatcher {
+  const registry = new Registry();
+
+  registry.add("/orders", {
+    GET() {
+      return {
+        body: "orders",
+        contentType: "text/plain",
+        headers: { "X-Original": "yes" },
+        status: 200,
+      };
+    },
+  });
+  registry.add("/users", {
+    GET() {
+      return { body: "users", contentType: "text/plain", status: 200 };
+    },
+  });
+
+  return new Dispatcher(
+    registry,
+    new ContextRegistry(),
+    undefined,
+    { validateRequests: false, validateResponses: false },
+    "",
+    [],
+    chaosRegistry,
+  );
+}
+
+async function get(dispatcher: Dispatcher, path: string) {
+  return dispatcher.request({
+    body: "",
+    headers: {},
+    method: "GET",
+    path,
+    query: {},
+    req: { path },
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
+
+describe("ChaosRule", () => {
+  it("applies indefinitely by default and preserves untouched fields", () => {
+    const rule = new ChaosRule("").status(503);
+    const response = {
+      body: "ok",
+      contentType: "text/plain",
+      headers: { keep: "yes" },
+      status: 200,
+    };
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      expect(rule.tryApply(response)?.response).toEqual({
+        ...response,
+        status: 503,
+      });
+    }
+  });
+
+  it("applies only to the configured next count", () => {
+    const rule = new ChaosRule("").next(2).status(500);
+    const response = { body: "ok", status: 200 };
+
+    expect(rule.tryApply(response)?.response.status).toBe(500);
+    expect(rule.tryApply(response)?.response.status).toBe(500);
+    expect(rule.tryApply(response)).toBeNull();
+  });
+
+  it("does not consume its count when stopped or skipped by probability", () => {
+    const rule = new ChaosRule("").next(2).probability(0).status(500);
+    const response = { body: "ok", status: 200 };
+
+    expect(rule.tryApply(response)).toBeNull();
+    rule.stop().probability(1);
+    expect(rule.tryApply(response)).toBeNull();
+    rule.start();
+    expect(rule.tryApply(response)).not.toBeNull();
+    expect(rule.tryApply(response)).not.toBeNull();
+    expect(rule.tryApply(response)).toBeNull();
+  });
+
+  it("never fires at probability zero, even when Math.random returns zero", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    expect(
+      new ChaosRule("").probability(0).tryApply({ body: "ok", status: 200 }),
+    ).toBeNull();
+  });
+
+  it.each([-0.1, 1.1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid probability of %s",
+    (probability) => {
+      expect(() => new ChaosRule("").probability(probability)).toThrow(
+        RangeError,
+      );
+    },
+  );
+
+  it("lets the last body mutation win", () => {
+    const rule = new ChaosRule("")
+      .transformBody((body) => `${String(body)} transformed`)
+      .body("replacement")
+      .transformBody((body) => `${String(body)} final`);
+
+    expect(
+      rule.tryApply({ body: "original", status: 200 })?.response.body,
+    ).toBe("original final");
+  });
+
+  it("applies header mutations case-insensitively with the last call winning", () => {
+    const response = {
+      body: "ok",
+      headers: { "X-First": "original", "X-Second": "original" },
+      status: 200,
+    };
+    const result = new ChaosRule("")
+      .header("x-first", "changed")
+      .removeHeader("X-FIRST")
+      .removeHeader("x-second")
+      .header("X-SECOND", "changed")
+      .tryApply(response);
+
+    expect(result?.response.headers).toEqual({ "X-SECOND": "changed" });
+  });
+
+  it("protects Content-Type under every casing", () => {
+    const response = {
+      body: "ok",
+      contentType: "application/json",
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    };
+    const result = new ChaosRule("")
+      .header("CONTENT-TYPE", "text/plain")
+      .removeHeader("content-type")
+      .tryApply(response);
+
+    expect(result?.response).toMatchObject(response);
+  });
+});
+
+describe("ChaosRegistry", () => {
+  it("selects the longest matching prefix", () => {
+    const registry = new ChaosRegistry();
+    registry.createRule("").status(500);
+    const orders = registry.createRule("/orders").status(429);
+
+    expect(registry.findBestMatch("/orders/1")).toBe(orders);
+    expect(registry.findBestMatch("/inventory/orders")).not.toBe(orders);
+  });
+
+  it("selects the most recently updated equal-prefix rule", () => {
+    const registry = new ChaosRegistry();
+    const first = registry.createRule("/orders").status(500);
+    registry.createRule("/orders").status(429);
+
+    first.stop().start();
+
+    expect(registry.findBestMatch("/orders/1")).toBe(first);
+  });
+
+  it("skips stopped and exhausted rules", () => {
+    const registry = new ChaosRegistry();
+    registry.createRule("/orders").stop();
+    const exhausted = registry.createRule("/orders").next();
+    exhausted.tryApply({ body: "ok", status: 200 });
+
+    expect(registry.findBestMatch("/orders")).toBeUndefined();
+  });
+});
+
+describe("Dispatcher chaos integration", () => {
+  it("applies a shared global rule across routes", async () => {
+    const registry = new ChaosRegistry();
+    registry.createRule().status(503);
+    const dispatcher = makeDispatcher(registry);
+
+    expect((await get(dispatcher, "/orders")).status).toBe(503);
+    expect((await get(dispatcher, "/users")).status).toBe(503);
+  });
+
+  it("applies a scoped rule only to matching routes", async () => {
+    const registry = new ChaosRegistry();
+    registry.createRule("/orders").status(429);
+    const dispatcher = makeDispatcher(registry);
+
+    expect((await get(dispatcher, "/orders")).status).toBe(429);
+    expect((await get(dispatcher, "/users")).status).toBe(200);
+  });
+
+  it("delays a response and always restores fake timers", async () => {
+    jest.useFakeTimers();
+    const registry = new ChaosRegistry();
+    registry.createRule("/orders").delay(2_000);
+    const responsePromise = get(makeDispatcher(registry), "/orders");
+
+    await jest.runAllTimersAsync();
+
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+});

--- a/packages/runtime/test/server/chaos.test.ts
+++ b/packages/runtime/test/server/chaos.test.ts
@@ -103,6 +103,19 @@ describe("ChaosRule", () => {
     },
   );
 
+  it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects an invalid delay of %s",
+    (delay) => {
+      expect(() => new ChaosRule("").delay(delay)).toThrow(RangeError);
+    },
+  );
+
+  it.each([0, 2_000])("accepts the valid delay %s", (delay) => {
+    expect(
+      new ChaosRule("").delay(delay).tryApply({ body: "ok", status: 200 }),
+    ).toMatchObject({ delayMs: delay });
+  });
+
   it("accepts zero as an exhausted next count", () => {
     const rule = new ChaosRule("").next(0);
 

--- a/packages/runtime/test/server/chaos.test.ts
+++ b/packages/runtime/test/server/chaos.test.ts
@@ -78,6 +78,19 @@ describe("ChaosRule", () => {
     expect(rule.tryApply(response)).toBeNull();
   });
 
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid next count of %s",
+    (count) => {
+      expect(() => new ChaosRule("").next(count)).toThrow(RangeError);
+    },
+  );
+
+  it("accepts zero as an exhausted next count", () => {
+    const rule = new ChaosRule("").next(0);
+
+    expect(rule.isEligible).toBe(false);
+  });
+
   it("does not consume its count when stopped or skipped by probability", () => {
     const rule = new ChaosRule("").next(2).probability(0).status(500);
     const response = { body: "ok", status: 200 };

--- a/packages/runtime/test/server/chaos.test.ts
+++ b/packages/runtime/test/server/chaos.test.ts
@@ -85,6 +85,24 @@ describe("ChaosRule", () => {
     },
   );
 
+  it.each([99, 600, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid status code of %s",
+    (status) => {
+      expect(() => new ChaosRule("").status(status)).toThrow(RangeError);
+    },
+  );
+
+  it.each([100, 200, 404, 599])(
+    "accepts the valid status code %s",
+    (status) => {
+      expect(
+        new ChaosRule("")
+          .status(status)
+          .tryApply({ body: "ok", status: 200 }),
+      ).toMatchObject({ response: { status } });
+    },
+  );
+
   it("accepts zero as an exhausted next count", () => {
     const rule = new ChaosRule("").next(0);
 


### PR DESCRIPTION
## Summary

- add runtime-owned `ChaosRule` and `ChaosRegistry` APIs for HTTP-response fault injection
- expose one server-level registry through every dispatcher and the live REPL, including multi-API simulators
- support bounded/probabilistic faults, status, delay, case-insensitive header mutation, body replacement/transformation, and lifecycle controls
- document the public runtime, REPL, reference, and usage-pattern contracts
- supersedes #2119 with an implementation based on the monorepo package boundaries

## Original Prompt

Add a `chaos()` API for HTTP-layer fault injection.

## Manual acceptance tests

- [ ] From the Live REPL, run `chaos("/orders").next(3).status(503)` and confirm exactly three matching responses return 503.
- [ ] Add a probabilistic rule, stop and restart it, and confirm skipped or stopped requests do not consume its remaining count.
- [ ] In a multi-API simulator, create one global REPL rule and confirm matching routes in two different API groups are affected.
- [ ] Set and remove the same response header with different casing; confirm the last call wins while `Content-Type` remains unchanged.
- [ ] Add a delayed response rule, then stop it; confirm normal responses resume without restarting Counterfact.

## Tasks

- [x] Put chaos rule behavior and public exports in `@counterfact/runtime`.
- [x] Apply the selected rule after normal dispatcher response processing.
- [x] Expose a supplied runtime registry through `@counterfact/repl` without deep imports.
- [x] Share exactly one registry across every facade runner and REPL session.
- [x] Add package, reference, feature, and pattern documentation.
- [x] Add patch changesets for runtime, REPL, and `counterfact`.

## Repository learning check

- [x] Runtime owns HTTP behavior; REPL only exposes a supplied public runtime contract.
- [x] The facade owns simulator-level composition and shares one registry across API groups.
- [x] Existing grouped context/scenario boundaries and positional API compatibility are preserved.
- [x] Removed historical APIs were not restored: indefinite application is the default, with no `always()` or `timeout()`.

## Verification

- `./node_modules/.bin/tsc --build packages/runtime/tsconfig.json packages/repl/tsconfig.json packages/counterfact/tsconfig.json --force --pretty false`
- changed-file ESLint (no errors)
- full Jest run: 65 suites, 933 passing, 1 todo, 127 snapshots
- `node scripts/check-package-boundaries.mjs`
- `npm_config_cache=/private/tmp/counterfact-npm-cache node scripts/check-publishable.mjs`
- `npm_config_cache=/private/tmp/counterfact-npm-cache npm exec --yes --package=yarn@1.22.22 -- node scripts/test-package-closures.mjs`
- `git diff --check`

The polling override used for watcher-heavy Jest runs avoids the current macOS sandbox's file-descriptor limit; production watcher configuration is unchanged.
