### PR TITLE
fix(ci): enable automatic npm publication

### DIFF
--- a/.github/skills/counterfact-maintenance/SKILL.md
+++ b/.github/skills/counterfact-maintenance/SKILL.md
@@ -11,6 +11,8 @@ applyTo:
   - "test-black-box/**/*.py"
   - "docs/**/*.md"
   - ".changeset/*.md"
+  - ".github/workflows/**/*.yaml"
+  - ".github/workflows/**/*.yml"
 ---
 
 # Counterfact Maintenance Skill
@@ -35,6 +37,8 @@ Use this skill when finalizing contributor-facing changes that affect tests, dia
 - Preserve documented behavior promises (e.g., regen preserves route edits; types are regenerated).
 - For user-facing behavior changes: add a changeset and update docs under `packages/counterfact/docs/`.
 - After Changesets versions workspace packages, run `yarn install --mode skip-build` so `yarn.lock` matches the new internal versions before immutable installation.
+- A push to `main` with no remaining changesets publishes the merged package versions automatically; a manual Release workflow dispatch is the retry and recovery path.
+- Keep the `npm-publish` environment name, OIDC permission, and provenance setting aligned with the npm trusted-publisher configuration.
 - Use OS-assigned ephemeral ports for tests that start network servers; fixed high ports can collide on shared CI hosts.
 
 ## Black-box test boundary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish versions already merged to main
-        required: true
-        type: boolean
-        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -52,9 +46,8 @@ jobs:
     name: Publish to npm
     needs: prepare
     if: >-
-      github.event_name == 'workflow_dispatch' &&
-      inputs.publish &&
-      needs.prepare.outputs.has_changesets != 'true'
+      needs.prepare.outputs.has_changesets != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: npm-publish
 


### PR DESCRIPTION
## Summary

Enable the Release workflow to publish merged package versions automatically on pushes to `main` when no pending changesets remain. Manual dispatch remains available as a retry/recovery path.

The existing npm trusted-publishing environment, OIDC permission, verified build, and provenance settings are unchanged.

## Tests

- `git diff --check` passed.
- Prettier passed for both changed files.
- Repository lint passed with 0 errors and 145 pre-existing warnings.
- Release preflight passed package-boundary, isolated-closure, and npm-packaging checks. Its final Changesets status correctly reports already-versioned packages with no changesets on this CI-only branch.
- Publication-condition truth table passed for push, manual dispatch, pending changesets, and unrelated events.

## Manual acceptance tests

- [ ] Merge a Changesets version PR and observe the resulting push to `main` publish the new package versions to npm.
- [ ] Push a change containing pending changesets and observe the version PR update without an npm publication attempt.
- [ ] Manually dispatch the Release workflow with no pending changesets and observe the recovery publication path run safely.
- [ ] Confirm the published packages retain provenance and the expected GitHub release/tag metadata.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): `.github/skills/counterfact-maintenance/SKILL.md`
- Rationale: Automatic publication after a version PR merge and manual-dispatch recovery are durable repository release conventions.