### PR TITLE
fix(release): allow version script to update lockfile on CI

### DIFF
--- a/.github/skills/counterfact-maintenance/SKILL.md
+++ b/.github/skills/counterfact-maintenance/SKILL.md
@@ -36,7 +36,7 @@ Use this skill when finalizing contributor-facing changes that affect tests, dia
 - Keep tests focused by subsystem (`packages/counterfact/test/cli`, `packages/counterfact/test/server`, `packages/counterfact/test/typescript-generator`, `packages/counterfact/test/util`).
 - Preserve documented behavior promises (e.g., regen preserves route edits; types are regenerated).
 - For user-facing behavior changes: add a changeset and update docs under `packages/counterfact/docs/`.
-- After Changesets versions workspace packages, run `yarn install --mode skip-build` so `yarn.lock` matches the new internal versions before immutable installation.
+- After Changesets versions workspace packages, run `yarn install --mode skip-build --no-immutable` so `yarn.lock` can match the new internal versions before immutable installation; CI enables Yarn immutability by default, so the explicit override is required in `release:version`.
 - A push to `main` with no remaining changesets publishes the merged package versions automatically; a manual Release workflow dispatch is the retry and recovery path.
 - Keep the `npm-publish` environment name, OIDC permission, and provenance setting aligned with the npm trusted-publisher configuration.
 - Use OS-assigned ephemeral ports for tests that start network servers; fixed high ports can collide on shared CI hosts.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "yarn workspace counterfact build",
     "typecheck": "tsc --noEmit --pretty false -p packages/types && tsc --noEmit --pretty false -p packages/openapi && tsc --noEmit --pretty false -p packages/runtime && tsc --noEmit --pretty false -p packages/client && tsc --noEmit --pretty false -p packages/generator && tsc --noEmit --pretty false -p packages/repl && tsc --noEmit --pretty false -p packages/counterfact",
     "release:preflight": "node scripts/release-preflight.mjs",
-    "release:version": "changeset version && yarn install --mode skip-build",
+    "release:version": "changeset version && yarn install --mode skip-build --no-immutable",
     "release": "changeset publish",
     "prepare": "husky install",
     "lint": "eslint . --plugin file-progress --rule 'file-progress/activate: 1' --ignore-pattern dist --ignore-pattern out --ignore-pattern coverage",


### PR DESCRIPTION
## Summary

Fix the Release workflow failure after `changeset version` updates internal workspace versions. On GitHub Actions, Yarn enables immutable installs by default, so the lockfile-refresh install in `release:version` failed with `YN0028`.

The version script now passes `--no-immutable` for that intentional lockfile update. The publish job continues to use its explicit immutable install.

## Tests

- `git diff --check` passed.
- Prettier passed for `package.json` and the maintenance skill.
- The updated release script value was verified from parsed `package.json`.
- `yarn install --mode skip-build --no-immutable` completed successfully with expected peer-dependency warnings.
- Full lint was attempted; unchanged workspace examples report import-resolution errors in a fresh worktree because build-generated workspace links are absent.

## Manual acceptance tests

- [ ] Merge the PR and observe the Release workflow version-preparation job complete after `changeset version` updates workspace versions and `yarn.lock`.
- [ ] Observe a qualifying `main` push proceed to the npm publication job instead of failing with Yarn error `YN0028`.
- [ ] Push a change with pending changesets and confirm the version PR is created or updated without publishing.
- [ ] Confirm the publish job still installs with `--immutable` and publishes with the configured npm trusted-publishing environment and provenance.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): `.github/skills/counterfact-maintenance/SKILL.md`
- Rationale: CI enables Yarn immutability by default, so release versioning must explicitly opt out when it intentionally refreshes the lockfile.