### PR TITLE
Add reproducible Counterfact devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,15 @@
-# [Choice] Node.js version
-ARG VARIANT=22-bookworm
-FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
+FROM node:24.19.0-bookworm-slim
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+USER root
 
-# [Optional] Uncomment if you want to install an additional version of node using nvm
-# ARG EXTRA_NODE_VERSION=10
-# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        git \
+        python3 \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
 
-# [Optional] Uncomment if you want to install more global node packages
-RUN su node -c "npm install -g ts-node"
+RUN corepack enable
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,24 @@
 {
-  "name": "Counterfact",
+  "name": "Counterfact (Node 24 + Python)",
   "build": {
     "dockerfile": "Dockerfile",
-    "args": {
-      "VARIANT": "22-bookworm"
-    }
+    "context": ".."
   },
+  "containerUser": "node",
+  "remoteUser": "node",
+  "updateRemoteUserUID": true,
+  "workspaceFolder": "/workspaces/counterfact",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/counterfact,type=bind,consistency=cached",
+  "init": true,
+  "privileged": false,
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker",
+        "usernamehw.errorlens"
+      ],
       "settings": {
         "editor.formatOnSave": true,
         "eslint.format.enable": true,
@@ -34,14 +45,7 @@
         "[typescript]": {
           "editor.defaultFormatter": "dbaeumer.vscode-eslint"
         }
-      },
-      "extensions": [
-        "dbaeumer.vscode-eslint",
-        "ms-azuretools.vscode-docker",
-        "usernamehw.errorlens"
-      ]
+      }
     }
-  },
-  "postCreateCommand": "corepack enable && yarn install",
-  "remoteUser": "node"
+  }
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+yarn install --immutable
+
+venv_path="${COUNTERFACT_VENV_PATH:-/tmp/counterfact-venv}"
+python3 -m venv "$venv_path"
+"$venv_path/bin/python" -m pip install --requirement test-black-box/requirements.txt

--- a/.devcontainer/verify.sh
+++ b/.devcontainer/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+yarn install --immutable
+yarn build
+yarn test:boundaries
+yarn check:boundaries
+yarn lint
+yarn typecheck
+yarn test:packed-consumer
+yarn test:package-closures
+yarn test --runInBand --forceExit --verbose --no-watchman
+
+venv_path="${COUNTERFACT_VENV_PATH:-/tmp/counterfact-venv}"
+if [[ ! -x "$venv_path/bin/python" ]]; then
+  python3 -m venv "$venv_path"
+fi
+"$venv_path/bin/python" -m pip install --requirement test-black-box/requirements.txt
+PATH="$venv_path/bin:$PATH" yarn test:black-box
+yarn build
+yarn test:tsd

--- a/.github/skills/counterfact-repo-basics/SKILL.md
+++ b/.github/skills/counterfact-repo-basics/SKILL.md
@@ -58,6 +58,19 @@ site/                         # Documentation website
 | Lint (auto-fix)               | `yarn lint:fix`                  |
 | Run against Petstore          | `yarn go:petstore`               |
 
+## Development container
+
+The repository's `.devcontainer` supplies the reproducible Linux development
+environment used for contributor validation: Node 24, Corepack/Yarn 4, and
+Python dependencies for black-box tests. Use the non-root `node` user and keep
+the container limited to the intended repository mount; do not expose Docker,
+host credentials, SSH agents, or production secrets.
+
+Run `bash .devcontainer/verify.sh` inside the container for the Linux
+CI-equivalent suite. Codex Desktop's native workspace sandbox remains separate
+from the development container: use the devcontainer for reproducible
+dependencies and tests, and use a dedicated Git worktree/branch for each task.
+
 ## New issue proposals
 
 Never create GitHub issues directly. Propose them as Markdown files under `.github/issue-proposals/` and follow `.github/instructions/issue-proposals.instructions.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,53 @@ and server runtime are currently part of the `counterfact` workspace. Root
 scripts coordinate builds and checks, so contributors do not need to change
 directories for the standard workflow.
 
+### Development container
+
+Counterfact includes a [Development Container](./.devcontainer/devcontainer.json)
+for a reproducible Node 24, Yarn 4, and Python environment. It is intended for
+local development and testing; it does not grant a coding agent access outside
+the checked-out repository.
+
+Install Docker Desktop and a Dev Containers-compatible editor, then open this
+repository and choose **Reopen in Container**. The container enables Corepack;
+its post-create setup installs the immutable Yarn dependency tree and installs
+the Python dependencies used by the black-box test suite into a container-local
+virtual environment.
+
+Run the full Linux CI-equivalent check inside the container with:
+
+```sh
+bash .devcontainer/verify.sh
+```
+
+#### Codex Desktop
+
+The development container makes dependencies reproducible. Codex Desktop's
+native sandbox remains the boundary for agent commands, so a devcontainer does
+not automatically make every Desktop command execute inside Docker.
+
+In ChatGPT Desktop, select **Codex**, open the project local-environment
+settings, and add actions that run these commands in the integrated terminal:
+
+```sh
+# Set up a newly created worktree
+yarn install --immutable
+
+# Fast checks
+yarn lint && yarn typecheck && yarn test
+
+# Product black-box tests
+yarn build && yarn test:black-box
+
+# Full Linux CI-equivalent check (when the worktree is opened in the container)
+bash .devcontainer/verify.sh
+```
+
+Use a separate Git worktree and branch for each task. After the required checks
+pass, task branches may be pushed and opened as pull requests; releases,
+deployments, production data, paid services, and credential changes require
+separate authorization.
+
 ### Mutation testing
 
 Mutation testing runs against one workspace package at a time so reports stay actionable and CI can process packages in parallel.


### PR DESCRIPTION
## Summary

- Update the existing development container to Node 24 with Python, Git, build tooling, and Corepack for Counterfact's Yarn 4 and black-box test workflow.
- Add non-root setup and Linux CI-equivalent verification scripts that keep Python dependencies inside the container rather than writing a platform-specific virtual environment into the checkout.
- Document the devcontainer, Codex Desktop sandbox boundary, per-task worktree workflow, and reusable contributor guidance.

## Manual acceptance tests

- [x] Open a Counterfact checkout in a Dev Containers-compatible editor and confirm it starts as the non-root `node` user with Node 24 and Python available.
- [x] Reopen the repository in the container and confirm post-create setup installs Yarn dependencies and black-box Python dependencies without creating `.venv`, `bin/`, or `lib/` in the checkout.
- [x] Run `bash .devcontainer/verify.sh` inside the container and confirm the build, lint, package-consumer, unit, black-box, and type-test checks complete successfully.
- [x] Create a second Git worktree for a small change and confirm the documented setup command initializes its dependencies independently of the integration checkout.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): .github/skills/counterfact-repo-basics/SKILL.md
- Rationale: The reproducible Node/Python container setup and its separation from Codex Desktop sandboxing are durable contributor workflow guidance.