### PR TITLE
test(repl): raise mutation score to 80%

### DIFF
--- a/packages/repl/test/repl.test.ts
+++ b/packages/repl/test/repl.test.ts
@@ -272,6 +272,31 @@ describe("REPL", () => {
     ]);
   });
 
+  it("describes the root proxy target when the proxy URL is not configured", () => {
+    const { config, harness } = createHarness();
+
+    config.proxyUrl = "";
+    harness.call("proxy", "on");
+
+    expect(config.proxyPaths.get("")).toBe(true);
+    expect(harness.output).toEqual([
+      "Requests to / will be proxied to <proxy URL>/",
+    ]);
+    expect(harness.isReset()).toBe(true);
+  });
+
+  it("sorts proxy status paths before displaying them", () => {
+    const { config, harness } = createHarness();
+
+    config.proxyPaths.set("/zebra", false);
+    config.proxyPaths.set("/alpha", true);
+
+    harness.call("proxy", "status");
+
+    expect(harness.output.slice(-2)).toEqual(["[+] /alpha/", "[-] /zebra/"]);
+    expect(harness.isReset()).toBe(true);
+  });
+
   it.each(["", "help"])("displays a proxy help message (%s)", () => {
     const { harness } = createHarness();
 
@@ -727,6 +752,64 @@ describe("REPL", () => {
       await harness.callAsync("scenario", "../secret/foo");
 
       expect(harness.output[0]).toMatch(/Error: Path must not contain/u);
+      expect(harness.isReset()).toBe(true);
+    });
+
+    it("rejects dot-only scenario path segments", async () => {
+      const { harness } = createHarness();
+
+      await harness.callAsync("scenario", "./setup");
+
+      expect(harness.output).toEqual([
+        "Error: Path must not contain '.' or '..' segments",
+      ]);
+      expect(harness.isReset()).toBe(true);
+    });
+
+    it("reports an error when the scenario function throws", async () => {
+      const scenarioRegistry = new ScenarioRegistry();
+      scenarioRegistry.add("index", {
+        setup() {
+          throw new Error("seed data unavailable");
+        },
+      });
+      const { harness } = createHarness(scenarioRegistry);
+
+      await harness.callAsync("scenario", "setup");
+
+      expect(harness.output).toEqual(["Error: Error: seed data unavailable"]);
+      expect(harness.isReset()).toBe(true);
+    });
+
+    it("reports an error when a selected multi-API group has no routes binding", async () => {
+      const scenarioRegistry = new ScenarioRegistry();
+      scenarioRegistry.add("index", { setup() {} });
+      const { harness } = createHarness(undefined, [
+        {
+          contextRegistry: new ContextRegistry(),
+          group: "billing",
+          registry: new Registry(),
+          scenarioRegistry,
+        },
+        {
+          contextRegistry: new ContextRegistry(),
+          group: "inventory",
+          registry: new Registry(),
+          scenarioRegistry: new ScenarioRegistry(),
+        },
+      ]);
+
+      delete (
+        harness.server.context["routes"] as Record<
+          string,
+          Record<string, unknown>
+        >
+      )["billing"];
+      await harness.callAsync("scenario", "billing setup");
+
+      expect(harness.output).toEqual([
+        'Error: Could not resolve routes for API group "billing"',
+      ]);
       expect(harness.isReset()).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Add REPL behavior tests for root proxy messaging and deterministic proxy-status ordering.
- Cover dot-path rejection, scenario failures, and unavailable multi-API route bindings.
- Raise the REPL incremental mutation score from 78.05% to 80.08% (418/522 detected mutants).

## Validation

- `yarn workspace @counterfact/repl test`
- `yarn test:mutation:incremental --package repl`
- `yarn lint`
- `yarn typecheck`

## Manual acceptance tests

- [ ] With no proxy URL configured, enter `.proxy on` and confirm the REPL says root requests will use `<proxy URL>/`.
- [ ] Configure `/zebra` and `/alpha` proxy paths in reverse order, run `.proxy status`, and confirm the displayed paths are alphabetically ordered.
- [ ] Run `.scenario ./setup` and confirm the REPL rejects the dot path without applying a scenario.
- [ ] Run a scenario function that throws and confirm the REPL displays the error while remaining usable for the next command.
- [ ] In a multi-API REPL, invoke a scenario after its selected group has no routes binding and confirm the group-specific error is displayed.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: The change follows existing REPL harness and focused behavioral-test conventions without revealing a reusable repository rule that is not already documented.