### PR TITLE
fix(runtime): validate implicit 200 responses

### DIFF
--- a/.changeset/implicit-success-validation.md
+++ b/.changeset/implicit-success-validation.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Validate responses that omit an explicit status against the OpenAPI `200` response definition.

--- a/packages/counterfact/docs/faq.md
+++ b/packages/counterfact/docs/faq.md
@@ -203,7 +203,7 @@ Yes, for required query, header, and cookie parameters and supported JSON/form r
 
 ## Does it validate outgoing responses?
 
-Yes, by default. Response headers are validated against the schema defined in the spec. Any validation errors (missing required headers or type mismatches) are reported as `response-type-error` HTTP response headers — one header per error; multiple headers with the same name are allowed. The response body is still returned normally — the errors are advisory only. Disable this with `--no-validate-response` if you need looser behavior.
+Yes, by default. Response headers are validated against the schema defined in the spec. When a handler omits `status`, Counterfact validates it against the `200` response definition, matching the status sent over HTTP. Any validation errors (missing required headers or type mismatches) are reported as `response-type-error` HTTP response headers — one header per error; multiple headers with the same name are allowed. The response body is still returned normally — the errors are advisory only. Disable this with `--no-validate-response` if you need looser behavior.
 
 ---
 

--- a/packages/runtime/src/server/response-validator.ts
+++ b/packages/runtime/src/server/response-validator.ts
@@ -24,12 +24,13 @@ export function validateResponse(
 
   const errors: string[] = [];
 
-  const statusKey =
-    response.status !== undefined ? String(response.status) : undefined;
+  // The HTTP layer sends 200 when a handler omits status. Validate against the
+  // same effective status so an implicit success response cannot bypass its
+  // OpenAPI response contract.
+  const statusKey = String(response.status ?? 200);
 
   const responseSpec =
-    (statusKey !== undefined ? operation.responses[statusKey] : undefined) ??
-    operation.responses.default;
+    operation.responses[statusKey] ?? operation.responses.default;
 
   if (!responseSpec) {
     return { errors: [], valid: true };

--- a/packages/runtime/test/server/dispatcher.test.ts
+++ b/packages/runtime/test/server/dispatcher.test.ts
@@ -2122,12 +2122,17 @@ describe("given a request that contains the differently cased path", () => {
     function makeResponseDispatcher(
       validateResponses: boolean,
       handlerHeaders: Record<string, string> = {},
+      includeStatus = true,
     ) {
       const registry = new Registry();
 
       registry.add("/widgets", {
         GET() {
-          return { body: "ok", headers: handlerHeaders, status: 200 };
+          return {
+            body: "ok",
+            headers: handlerHeaders,
+            ...(includeStatus ? { status: 200 } : {}),
+          };
         },
       });
 
@@ -2168,6 +2173,25 @@ describe("given a request that contains the differently cased path", () => {
         .map(([, value]) => value);
 
       expect(errorValues?.[0]).toContain("x-required-header");
+    });
+
+    it("validates an implicit 200 response against the 200 response spec", async () => {
+      const dispatcher = makeResponseDispatcher(true, {}, false);
+
+      const response = await dispatcher.request({
+        body: "",
+        headers: {},
+        method: "GET",
+        path: "/widgets",
+        query: {},
+        req: { path: "/widgets" },
+      });
+
+      expect(response.status).toBeUndefined();
+      expect(response.appendedHeaders).toContainEqual([
+        "response-type-error",
+        "response header 'x-required-header' is required",
+      ]);
     });
 
     it("adds response-type-error headers when a response header has the wrong type", async () => {

--- a/packages/runtime/test/server/response-validator.test.ts
+++ b/packages/runtime/test/server/response-validator.test.ts
@@ -179,6 +179,45 @@ describe("validateResponse", () => {
     expect(result.errors[0]).toContain("x-required");
   });
 
+  it("uses the 200 response spec when response status is undefined", () => {
+    const result = validateResponse(
+      {
+        responses: {
+          200: {
+            content: {},
+            headers: {
+              "x-required": { required: true, schema: { type: "string" } },
+            },
+          },
+          default: { content: {} },
+        },
+      },
+      { body: "ok", headers: {} },
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("x-required");
+  });
+
+  it("does not use the 200 response spec for an explicit non-200 status", () => {
+    const result = validateResponse(
+      {
+        responses: {
+          200: {
+            content: {},
+            headers: {
+              "x-required": { required: true, schema: { type: "string" } },
+            },
+          },
+          201: { content: {} },
+        },
+      },
+      { body: "created", headers: {}, status: 201 },
+    );
+
+    expect(result).toStrictEqual({ errors: [], valid: true });
+  });
+
   it("returns multiple errors when multiple headers are invalid", () => {
     const result = validateResponse(
       {

--- a/test-black-box/features/generated_openapi.feature
+++ b/test-black-box/features/generated_openapi.feature
@@ -14,5 +14,7 @@ Feature: Generate and run an OpenAPI simulation
     And unacceptable response negotiation returns 406
     And a required header is enforced case-insensitively
     And invalid bodies are rejected while valid bodies are accepted
+    When I customize a handler that relies on the implicit success status
+    Then its implicit 200 response is still validated
     When I customize the generated binary handler
     Then the hot-reloaded handler serves the expected bytes and content type

--- a/test-black-box/test_generated_openapi_journey.py
+++ b/test-black-box/test_generated_openapi_journey.py
@@ -129,6 +129,24 @@ OPENAPI_DOCUMENT = {
                 }
             }
         },
+        "/implicit-status": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "implicit success",
+                        "headers": {
+                            "X-Required-Response": {
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        },
+                        "content": {
+                            "text/plain": {"schema": {"type": "string"}}
+                        },
+                    }
+                }
+            }
+        },
     },
 }
 
@@ -136,6 +154,13 @@ OPENAPI_DOCUMENT = {
 BINARY_HANDLER = """\
 export const GET = ($) => {
   return $.response[200].binary("aGVsbG8gYmluYXJ5");
+};
+"""
+
+
+IMPLICIT_STATUS_HANDLER = """\
+export const GET = () => {
+  return { body: "implicit success", contentType: "text/plain", headers: {} };
 };
 """
 
@@ -261,6 +286,27 @@ def request_bodies_are_validated(journey):
     assert invalid.status_code == 400
     assert "body must have required property 'name'" in invalid.text
     assert (valid.status_code, valid.text) == (200, "accepted")
+
+
+@when("I customize a handler that relies on the implicit success status")
+def customize_implicit_status_handler(journey):
+    (journey.output / "routes" / "implicit-status.ts").write_text(
+        IMPLICIT_STATUS_HANDLER, encoding="utf-8"
+    )
+
+
+@then("its implicit 200 response is still validated")
+def implicit_success_response_is_validated(journey):
+    response = journey.wait_for_http(
+        f"{journey.prefix}/implicit-status",
+        lambda candidate: (
+            candidate.status_code == 200
+            and candidate.text == "implicit success"
+            and "X-Required-Response"
+            in candidate.headers.get("response-type-error", "")
+        ),
+    )
+    assert "X-Required-Response" in response.headers["response-type-error"]
 
 
 @when("I customize the generated binary handler")


### PR DESCRIPTION
## Summary

- validate handler responses that omit `status` against the OpenAPI `200` response definition
- preserve explicit-status and `default` response behavior
- cover the regression through focused runtime tests and the shipped CLI journey
- document the implicit-success validation rule and release it with a runtime changeset

<details>
<summary>Original Prompt</summary>

Fix the confirmed bug where response validation is bypassed when a handler relies on the implicit HTTP 200 status. Create a dedicated branch and PR with a changeset.

</details>

## Manual acceptance tests

- [ ] A handler that omits `status` and a required `200` response header returns its body with a `response-type-error` header.
- [ ] Supplying the required header removes the validation error without requiring `status: 200`.
- [ ] A handler with an explicit non-200 status is validated against that response definition.
- [ ] An OpenAPI `default` response still applies when the effective status has no explicit response entry.

## Tasks

- Normalize response-spec selection to the effective HTTP status.
- Add unit, dispatcher, and black-box regression coverage.
- Update the response-validation FAQ and add a patch changeset.

## Verification

- `mise exec node@24 -- yarn build`
- `mise exec node@24 -- yarn workspace @counterfact/runtime test` — 28 suites, 367 tests passed
- `mise exec node@24 -- yarn typecheck`
- `mise exec node@24 -- yarn lint` — passed with existing warnings only
- `mise exec node@24 -- yarn test` — 64 suites, 945 tests, 127 snapshots passed
- Generated-OpenAPI black-box journey passed; the remaining four journeys also passed across the full/targeted runs
- `mise exec node@24 -- yarn test:packed-consumer`
- `mise exec node@24 -- yarn release:preflight`
- `git diff --check`

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: The defect is a localized status-default mismatch now captured by focused runtime and product-level regression tests; it did not reveal a new repository-wide contribution rule.
