### PR TITLE
Align agent guidance with the package monorepo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,15 @@
 
 <!-- Agent: replace this section with 3–6 unchecked checkboxes per AGENTS.md. Each must describe an observable behavior. -->
 
+<!-- Reviewer: check each box only after observing the behavior. All boxes must be checked before merge. -->
+
+## Repository learning check
+
+- Learning found: Yes/No
+- Guidance updated: Yes/No
+- Updated file(s): N/A
+- Rationale: Replace this text with one sentence explaining why repository guidance did or did not need to change.
+
 ## Tasks
 
 <!-- Copilot: list the main implementation steps you performed -->

--- a/.github/skills/counterfact-client-repl/SKILL.md
+++ b/.github/skills/counterfact-client-repl/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: counterfact-client-repl
+description: >
+  Change the immutable request builder, raw HTTP client, or embeddable REPL
+  while preserving package boundaries and interactive behavior.
+applyTo:
+  - "packages/client/src/**/*.ts"
+  - "packages/client/test/**/*.test.ts"
+  - "packages/repl/src/**/*.ts"
+  - "packages/repl/test/**/*.test.ts"
+---
+
+# Counterfact Client and REPL Skill
+
+## When to use this skill
+
+Use this skill for request-catalog behavior, immutable request building, raw HTTP requests, REPL globals, completion, commands, scenarios, or event reporting.
+
+## Files to inspect first
+
+- `packages/client/README.md`
+- `packages/client/src/route-builder.ts`
+- `packages/client/src/route-catalog.ts`
+- `packages/repl/README.md`
+- `packages/repl/src/repl.ts`
+- `packages/repl/test/repl.test.ts`
+
+## Existing conventions to follow
+
+- Keep request builders immutable: configuration methods return new builders so requests can be safely branched.
+- Keep `@counterfact/client` usable without starting the simulator or REPL.
+- Give the REPL narrow client and runtime contracts; do not import the facade or CLI telemetry policy.
+- Report REPL events through the guarded callback, omit command arguments, and never let reporter failure interrupt the session.
+- Preserve single-API and grouped multi-API globals, scenario behavior, and literal terminal interaction.
+
+## Common mistakes to avoid
+
+- Mutating a request builder in place.
+- Making the client depend on runtime or the `counterfact` facade.
+- Testing interactive behavior only through a completer or command callback instead of a real pseudo-terminal journey.
+- Logging REPL command arguments or allowing observability failures to break commands.
+
+## How to validate the change
+
+- Run `yarn test:client` or `yarn test:repl` for the affected package.
+- Run `yarn test:client-packed` or `yarn test:repl-packed` when exports or packaged behavior change.
+- Run `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`, and `yarn check:boundaries`.
+- For user-visible interactive changes, add or update a PTY black-box journey, update user docs, and add a changeset.

--- a/.github/skills/counterfact-generator-internals/SKILL.md
+++ b/.github/skills/counterfact-generator-internals/SKILL.md
@@ -4,10 +4,8 @@ description: >
   Modify TypeScript generator internals, OpenAPI parsing/schema handling, and
   generated file writing behavior without regressing regeneration guarantees.
 applyTo:
-  - "packages/counterfact/src/typescript-generator/**/*.ts"
-  - "packages/counterfact/src/server/openapi-document.ts"
-  - "packages/counterfact/src/server/load-openapi-document.ts"
-  - "packages/counterfact/test/typescript-generator/**/*.test.ts"
+  - "packages/generator/src/**/*.ts"
+  - "packages/generator/test/**/*.test.ts"
 ---
 
 # Counterfact Generator Internals Skill
@@ -18,12 +16,13 @@ Use this skill when changing OpenAPI loading/bundling, schema-to-type generation
 
 ## Files to inspect first
 
-- `packages/counterfact/src/typescript-generator/README.md`
-- `packages/counterfact/src/typescript-generator/code-generator.ts`
-- `packages/counterfact/src/typescript-generator/specification.ts`
-- `packages/counterfact/src/typescript-generator/requirement.ts`
-- `packages/counterfact/src/typescript-generator/repository.ts`
-- `packages/counterfact/src/typescript-generator/schema-type-coder.ts`
+- `packages/generator/README.md`
+- `packages/generator/src/README.md`
+- `packages/generator/src/code-generator.ts`
+- `packages/generator/src/specification.ts`
+- `packages/generator/src/requirement.ts`
+- `packages/generator/src/repository.ts`
+- `packages/generator/src/schema-type-coder.ts`
 
 ## Existing conventions to follow
 
@@ -31,6 +30,7 @@ Use this skill when changing OpenAPI loading/bundling, schema-to-type generation
 - Preserve regeneration contract: existing route files are not overwritten; generated types are overwritten.
 - Support OpenAPI features through typed coders and requirement traversal rather than ad-hoc string logic.
 - Keep generated output deterministic and formatted via existing script/repository pipeline.
+- Import OpenAPI document behavior through `@counterfact/openapi`; do not move runtime or facade policy into the generator.
 
 ## Common mistakes to avoid
 
@@ -41,6 +41,6 @@ Use this skill when changing OpenAPI loading/bundling, schema-to-type generation
 
 ## How to validate the change
 
-- Run: `yarn lint`, `yarn build`, `yarn test`.
-- Run focused generator tests first (affected coder + integration/snapshot tests in `packages/counterfact/test/typescript-generator/`).
+- Run focused generator tests first with `yarn test:generator`; use the affected Jest path while iterating.
+- Run: `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`, and `yarn check:boundaries`.
 - If behavior changes for generated artifacts, verify snapshots and relevant docs (`packages/counterfact/docs/reference.md`, `packages/counterfact/docs/faq.md`).

--- a/.github/skills/counterfact-maintenance/SKILL.md
+++ b/.github/skills/counterfact-maintenance/SKILL.md
@@ -5,12 +5,17 @@ description: >
   black-box test boundaries, release/versioning workflow, documentation
   requirements, and compatibility.
 applyTo:
-  - "packages/counterfact/src/**/*.ts"
-  - "packages/counterfact/test/**/*.ts"
+  - "AGENTS.md"
+  - "CONTRIBUTING.md"
+  - "package.json"
+  - "packages/*/src/**/*"
+  - "packages/*/test/**/*"
   - "packages/counterfact/docs/**/*.md"
-  - "test-black-box/**/*.py"
+  - "test-black-box/**/*"
   - "docs/**/*.md"
+  - "scripts/**/*"
   - ".changeset/*.md"
+  - ".github/pull_request_template.md"
   - ".github/workflows/**/*.yaml"
   - ".github/workflows/**/*.yml"
 ---
@@ -27,19 +32,35 @@ Use this skill when finalizing contributor-facing changes that affect tests, dia
 - `AGENTS.md`
 - `packages/counterfact/docs/reference.md`
 - `packages/counterfact/docs/faq.md`
-- `.changeset/*.md` (format examples)
-- `packages/counterfact/test/**/*` for existing patterns/fixtures
+- `.changeset/README.md` (format and release guidance)
+- The affected package's `README.md`, `package.json`, and tests
+- `.github/workflows/ci.yaml` for the complete CI verification contract
 
 ## Existing conventions to follow
 
-- Use `usingTemporaryFiles()` for filesystem-heavy tests.
-- Keep tests focused by subsystem (`packages/counterfact/test/cli`, `packages/counterfact/test/server`, `packages/counterfact/test/typescript-generator`, `packages/counterfact/test/util`).
+- Use `usingTemporaryFiles()` for filesystem-heavy tests. Standalone packed-consumer harnesses under `packages/*/test/package/` may use Node filesystem APIs because they run outside Jest and create isolated consumer installations.
+- Keep tests with their owning package. Use the root focused scripts for client, generator, runtime, and REPL tests while iterating.
 - Preserve documented behavior promises (e.g., regen preserves route edits; types are regenerated).
 - For user-facing behavior changes: add a changeset and update docs under `packages/counterfact/docs/`.
 - After Changesets versions workspace packages, run `yarn install --mode skip-build --no-immutable` so `yarn.lock` can match the new internal versions before immutable installation; CI enables Yarn immutability by default, so the explicit override is required in `release:version`.
 - A push to `main` with no remaining changesets publishes the merged package versions automatically; a manual Release workflow dispatch is the retry and recovery path.
 - Keep the `npm-publish` environment name, OIDC permission, and provenance setting aligned with the npm trusted-publisher configuration.
 - Use OS-assigned ephemeral ports for tests that start network servers; fixed high ports can collide on shared CI hosts.
+- Treat `yarn lint:fix` as a scoped repair command, not baseline verification. Run `yarn lint` first so unrelated files are not rewritten accidentally.
+- Run build-producing verification sequentially. Workspace builds remove and recreate shared `dist` directories, so concurrent black-box, TSD, packed-consumer, or package-closure commands can invalidate one another's outputs.
+
+## Verification by affected area
+
+| Area                 | Focused checks                                          | Broader checks when applicable                                                  |
+| -------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Facade or CLI        | affected `packages/counterfact/test` paths              | build, lint, typecheck, unit tests, black-box tests                             |
+| Runtime              | `yarn test:runtime`                                     | build, boundaries, unit tests, black-box tests for observable behavior          |
+| Generator            | `yarn test:generator`                                   | build, typecheck, snapshots, boundaries, package closures                       |
+| Client               | `yarn test:client`                                      | build, typecheck, packed consumer, boundaries                                   |
+| REPL                 | `yarn test:repl`                                        | build, typecheck, packed consumer, PTY black-box tests for interactive behavior |
+| OpenAPI or types     | affected Jest or TSD tests                              | build, typecheck, boundaries, package closures                                  |
+| Packaging or release | boundaries, publishable checks, package closures        | `yarn release:preflight`                                                        |
+| Agent guidance       | `yarn check:agent-guidance && yarn test:agent-guidance` | lint and Markdown review                                                        |
 
 ## Black-box test boundary
 
@@ -101,13 +122,14 @@ Keep that operating-system skip scoped to the real-terminal scenario so non-inte
 
 ## Common mistakes to avoid
 
-- Introducing direct fs imports in tests instead of `usingTemporaryFiles` helper.
+- Introducing direct fs imports in Jest tests instead of `usingTemporaryFiles`, or widening the packed-consumer exception.
 - Treating a Python-launched Node consumer as a product black-box test because it runs in a child process.
 - Testing a REPL completer callback directly instead of operating the CLI through a terminal.
 - Adding a direct pytest black-box test instead of extending or adding a Gherkin journey.
 - Sharing a generated project, fixed port, server process, or mutable contract across scenarios.
 - Omitting focused tests because a broad black-box test already covers the behavior.
 - Treating package-consumer coverage as proof that packed artifacts are complete.
+- Running build-producing verification in parallel and mistaking cross-command `dist` races for product failures.
 - Shipping behavior changes without docs + changeset updates.
 - Breaking backward compatibility unintentionally (CLI defaults, regeneration guarantees, response semantics).
 - Relying only on broad tests; skip targeted tests for touched areas.
@@ -116,13 +138,14 @@ Keep that operating-system skip scoped to the real-terminal scenario so non-inte
 ## Embedding learnings into guidance
 
 - When a non-trivial task reveals repeatable guidance, update the relevant skill file in the same PR, or create a new skill if applicable.
-- Put subsystem-specific learnings in the matching skill (`counterfact-cli-runtime`, `counterfact-runtime-architecture`, or `counterfact-generator-internals`).
+- Put subsystem-specific learnings in the matching CLI, runtime, generator, OpenAPI, or client/REPL skill.
 - Put cross-cutting learnings in `AGENTS.md` only when they do not belong to a single subsystem skill.
 
 ## How to validate the change
 
-- Baseline: `yarn lint:fix`, `yarn lint`, `yarn build`, `yarn test`.
+- Baseline: `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`.
 - Run targeted tests for touched modules before full test run.
 - If server startup or CLI behavior changed, run `yarn build` then `yarn test:black-box`.
 - For black-box changes, run the boundary searches above and resolve or explicitly reclassify every finding in the touched scope.
 - Ensure PR notes include manual acceptance tests with observable outcomes.
+- Run `yarn check:agent-guidance && yarn test:agent-guidance` when guidance, package layout, root scripts, or PR workflow documentation changes.

--- a/.github/skills/counterfact-openapi/SKILL.md
+++ b/.github/skills/counterfact-openapi/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: counterfact-openapi
+description: >
+  Change standalone OpenAPI loading, bundling, dereferencing, overlays, and
+  shared document handling while preserving focused-package boundaries.
+applyTo:
+  - "packages/openapi/src/**/*.ts"
+  - "packages/openapi/test/**/*.test.ts"
+  - "packages/runtime/src/server/openapi-document.ts"
+  - "packages/runtime/src/server/load-openapi-document.ts"
+  - "packages/runtime/src/server/openapi-watcher.ts"
+---
+
+# Counterfact OpenAPI Skill
+
+## When to use this skill
+
+Use this skill for OpenAPI file loading, reference resolution, bundling, ordered overlay application, or the runtime adapters that observe documents.
+
+## Files to inspect first
+
+- `packages/openapi/README.md`
+- `packages/openapi/src/load-openapi-document.ts`
+- `packages/openapi/src/apply-overlay.ts`
+- `packages/openapi/test/load-openapi-document.test.ts`
+- `packages/openapi/test/apply-overlay.test.ts`
+
+## Existing conventions to follow
+
+- Keep reusable document mechanisms in `@counterfact/openapi`; it does not own CLI telemetry or a long-running product lifecycle.
+- Apply overlays in the caller-provided order.
+- Use `loadOpenApiDocument` for complete dereferencing and `bundleOpenApiDocument` when internal references must remain.
+- Keep runtime watching and reload policy in `@counterfact/runtime`, consuming the OpenAPI package through declared exports.
+- Preserve compatibility with both OpenAPI and Swagger inputs supported by the facade.
+
+## Common mistakes to avoid
+
+- Duplicating document loading or overlay logic in the generator, runtime, or facade.
+- Deep-importing package source instead of using `@counterfact/openapi` exports.
+- Reordering overlays or silently changing dereference versus bundle semantics.
+- Adding application lifecycle, telemetry, or server dependencies to the focused OpenAPI package.
+
+## How to validate the change
+
+- Run affected tests under `packages/openapi/test/`, then `yarn test`.
+- Run `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn check:boundaries`.
+- If facade-visible document behavior changes, run `yarn test:black-box`, update user docs, and add a changeset.

--- a/.github/skills/counterfact-repo-basics/SKILL.md
+++ b/.github/skills/counterfact-repo-basics/SKILL.md
@@ -21,42 +21,45 @@ Counterfact is a TypeScript-based mock server generator that turns OpenAPI/Swagg
 npx counterfact@latest https://petstore3.swagger.io/api/v3/openapi.json api
 ```
 
-## Repository structure
+## Repository structure and ownership
 
 ```text
 packages/
-  counterfact/                # Published package workspace
-    src/
-      app.ts                  # Main entry point; generation + server + REPL orchestration
-      server/                 # Koa server, dispatcher, registry, hot-reload internals
-      typescript-generator/   # OpenAPI parsing and TypeScript generation
-      repl/                   # Interactive terminal for runtime state control
-      migrate/                # Helpers for migrating generated route files
-      util/                   # Shared utilities
-    bin/counterfact.js        # CLI entry point
-    test/                     # Jest unit tests
-    templates/                # Generator scaffold templates
-    docs/                     # Canonical user documentation
-  types/src/                  # Shared types copied into generated projects
+  types/                      # Dependency-light shared TypeScript contracts
+  openapi/                    # OpenAPI loading, bundling, dereferencing, overlays
+  generator/                  # Route, type, scenario, and template generation
+  runtime/                    # Dispatch, registries, validation, hot reload, adapters
+  client/                     # Immutable request builder and raw HTTP client
+  repl/                       # Embeddable REPL over client and runtime contracts
+  counterfact/                # Published facade, CLI, orchestration, migrations, docs
 test-black-box/               # Gherkin journeys with Python harness and step glue
 examples/                     # Checked consumer examples
 site/                         # Documentation website
 ```
 
+Read the root `README.md` for the package map and the affected package's `README.md` before changing a workspace. `packages/counterfact/src/app.ts` and `api-runner.ts` compose the focused packages; they do not own runtime or generator internals.
+
+Counterfact packages follow one-way dependency boundaries. `types` is the leaf; `openapi` depends on `types`; `generator` and `runtime` are siblings; `client` depends on `openapi`; `repl` depends on `client` and narrow runtime contracts; and the `counterfact` facade may depend on all focused packages. Never deep-import another workspace's `src/` or `dist/`. `scripts/check-package-boundaries.mjs` is the executable authority.
+
 ## Essential commands
 
-| Task                          | Command                          |
-| ----------------------------- | -------------------------------- |
-| Install dependencies          | `yarn install --immutable`       |
-| Build                         | `yarn build`                     |
-| Type-check                    | `yarn typecheck`                 |
-| Unit tests                    | `yarn test`                      |
-| Product black-box tests       | `yarn test:black-box`            |
-| Installed package smoke test  | `yarn test:packed-consumer`      |
-| TypeScript type tests         | `yarn build && yarn test:tsd`    |
-| Lint (check)                  | `yarn lint`                      |
-| Lint (auto-fix)               | `yarn lint:fix`                  |
-| Run against Petstore          | `yarn go:petstore`               |
+| Task                         | Command                                                 |
+| ---------------------------- | ------------------------------------------------------- |
+| Install dependencies         | `yarn install --immutable`                              |
+| Build                        | `yarn build`                                            |
+| Type-check                   | `yarn typecheck`                                        |
+| Unit tests                   | `yarn test`                                             |
+| Package boundary checks      | `yarn test:boundaries && yarn check:boundaries`         |
+| Product black-box tests      | `yarn test:black-box`                                   |
+| Installed package smoke test | `yarn test:packed-consumer`                             |
+| Exact package closure tests  | `yarn test:package-closures`                            |
+| TypeScript type tests        | `yarn build && yarn test:tsd`                           |
+| Agent guidance integrity     | `yarn check:agent-guidance && yarn test:agent-guidance` |
+| Lint (check)                 | `yarn lint`                                             |
+| Lint (auto-fix)              | `yarn lint:fix`                                         |
+| Run against Petstore         | `yarn go:petstore`                                      |
+
+Use the focused package scripts (`test:client`, `test:generator`, `test:runtime`, and `test:repl`) while iterating. Use `lint:fix` only as an explicit repair step after reviewing lint output; it is not a read-only verification command.
 
 ## New issue proposals
 

--- a/.github/skills/counterfact-runtime-architecture/SKILL.md
+++ b/.github/skills/counterfact-runtime-architecture/SKILL.md
@@ -6,9 +6,9 @@ description: >
 applyTo:
   - "packages/counterfact/src/app.ts"
   - "packages/counterfact/src/api-runner.ts"
-  - "packages/counterfact/src/server/**/*.ts"
-  - "packages/counterfact/src/util/**/*.ts"
-  - "packages/counterfact/test/server/**/*.test.ts"
+  - "packages/runtime/src/**/*.ts"
+  - "packages/runtime/src/**/*.cjs"
+  - "packages/runtime/test/**/*.test.ts"
   - "packages/counterfact/test/app.test.ts"
 ---
 
@@ -22,27 +22,30 @@ Use this skill when changing runtime orchestration, server dispatch flow, module
 
 - `packages/counterfact/src/app.ts`
 - `packages/counterfact/src/api-runner.ts`
-- `packages/counterfact/src/server/dispatcher.ts`
-- `packages/counterfact/src/server/module-loader.ts`
-- `packages/counterfact/src/server/web-server/create-koa-app.ts`
+- `packages/runtime/README.md`
+- `packages/runtime/src/server/dispatcher.ts`
+- `packages/runtime/src/server/module-loader.ts`
+- `packages/runtime/src/server/web-server/create-koa-app.ts`
 - `packages/counterfact/docs/reference.md` (architecture + runtime behavior)
 
 ## Existing conventions to follow
 
-- Keep orchestration in `app.ts` / `ApiRunner`; avoid leaking server details into generator modules.
+- Keep product orchestration in the `counterfact` facade's `app.ts` / `ApiRunner`; keep runtime mechanisms in `@counterfact/runtime` and avoid generator dependencies.
 - Keep subsystems separated (`registry`, `context-registry`, `module-loader`, `dispatcher`) and connected through explicit constructor interfaces.
 - Preserve hot-reload expectations: route/module changes should apply without restart and context should survive reloads.
 - Prefer graceful degradation with actionable errors (see `docs/development/design-principles.md`).
 
 ## Common mistakes to avoid
 
-- Coupling generator concerns into `packages/counterfact/src/server/*` code paths.
+- Coupling generator or facade concerns into `packages/runtime`.
+- Deep-importing another workspace instead of using its declared exports.
 - Breaking prefix/group/version routing derivation in `app.ts`.
 - Introducing restart-only behavior for changes currently handled by watch/reload paths.
 - Changing response defaults/content negotiation semantics unintentionally in `dispatcher` or Koa middleware.
 
 ## How to validate the change
 
-- Run: `yarn lint`, `yarn build`, `yarn test`.
-- Run focused runtime tests first (for touched areas), e.g. `packages/counterfact/test/server/dispatcher.test.ts`, `packages/counterfact/test/server/module-loader.test.ts`, `packages/counterfact/test/app.test.ts`.
+- Run focused runtime tests first with `yarn test:runtime`; use the affected Jest path while iterating.
+- Run: `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`, and `yarn check:boundaries`.
+- When facade orchestration changes, include `packages/counterfact/test/app.test.ts` and `packages/counterfact/test/api-runner.test.ts`.
 - Manually sanity-check startup + runtime flow with `yarn go:example` when behavior changes.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,10 @@ jobs:
             const docsOnly = files.every((file) => file.filename.toLowerCase().endsWith(".md"));
             core.setOutput("docs_only", docsOnly ? "true" : "false");
 
+      - name: Agent guidance integrity
+        if: matrix.os != 'windows-latest'
+        run: node scripts/check-agent-guidance.mjs
+
       - name: Skip heavy checks for docs-only changes
         if: steps.docs-only.outputs.docs_only == 'true'
         run: echo "Markdown-only pull request detected. Skipping lint/type/tests while keeping required checks green."
@@ -68,6 +72,9 @@ jobs:
       - name: Package Boundary Tests
         if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         run: yarn test:boundaries
+      - name: Agent Guidance Tests
+        if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
+        run: yarn test:agent-guidance
       - name: Package Boundaries
         if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         run: yarn check:boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Before making changes, load the most relevant skill and follow it as the primary
 - `.github/skills/counterfact-cli-runtime/SKILL.md`
 - `.github/skills/counterfact-runtime-architecture/SKILL.md`
 - `.github/skills/counterfact-generator-internals/SKILL.md`
+- `.github/skills/counterfact-openapi/SKILL.md`
+- `.github/skills/counterfact-client-repl/SKILL.md`
 - `.github/skills/counterfact-maintenance/SKILL.md`
 - `.github/skills/counterfact-repo-basics/SKILL.md`
 
@@ -24,6 +26,7 @@ Every PR description must include a section titled exactly `## Manual acceptance
 
 - Cover the main success path, at least one edge case, and one regression check where applicable.
 - Exception: if a PR only adds files under `.github/issue-proposals/`, this section may be omitted.
+- Leave the boxes unchecked when opening the PR. The reviewer checks them as the behaviors are observed; the merge check requires all listed tests to be checked before merge.
 
 ## Repository learning check
 
@@ -62,6 +65,8 @@ If no durable learning was discovered, explicitly record `Learning found: No` an
 ## File system operations in tests
 
 When tests need to read or write files, use `usingTemporaryFiles()` from `using-temporary-files`. Do not import `node:fs`, `fs`, `node:fs/promises`, or `fs/promises` directly in test files.
+
+Standalone packed-consumer smoke harnesses under `packages/*/test/package/` are the narrow exception. They run outside the Jest test environment and may use Node filesystem APIs to create and remove their isolated consumer installation.
 
 Use the helper methods:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,13 @@
 # Contributing
 
-## Where I need help
+## Where help is welcome
 
-- **Feedback:** First and foremost, send me feedback. What makes sense? What's confusing? What's missing? What's broken? [Send me an email](pmcelhaney@gmail.com), [open an issue](https://github.com/pmcelhaney/counterfact/issues/new), or [start a discussion](https://github.com/pmcelhaney/counterfact/discussions).
-- **Documentation:** There are probably typos in this very document. Please send PRs, large and small. You can do it right from your browser. If you're viewing this document in GitHub, click the pencil button in the top right corner.
-- **Graphic design:** I'm terrible at graphic design. I know good design when I see it, and I can tell you why it's good, but struggle with the creative process. Whether it's building a web site, designing a logo, brainstorming on a GUI, or fixing up some ugly Markdown code, I'll take whatever help I can get!
-- **Tests:** Test coverage is pretty good, but there are gaps. Filling those gaps is an easy way to gain some familiarity with the codebase.
-- **Code Generation:** As of this writing, the code that writes the code works okay, but it's kind of sloppy. Instead of printing strings of source code directly, I'd like to refactor everything to build ASTs. I'd also like to bring in [json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript), which is more accurate than my hand-rolled MVP.
-- **Convert to TypeScript**: While Counterfact generates and runs TypeScript, ironically the code itself is in JavaScript. That's partly because running the unit tests in Jest requires [--experimental-vm-modules](https://jestjs.io/docs/ecmascript-modules). Getting Jest working with that and TypeScript at the same time was too much trouble when the project was getting off the ground.
-- **New features and bug fixes:** See the [issues list](https://github.com/pmcelhaney/counterfact/issues). If you plan on working on something, please add a comment and/or assign yourself.
-- **Spread the word!** If you find this project useful, please let others know about it. Share it in your team Slack, on social media, etc.
+- **Feedback and questions:** [Start a discussion](https://github.com/pmcelhaney/counterfact/discussions) or [open an issue](https://github.com/pmcelhaney/counterfact/issues/new).
+- **Documentation and examples:** Improve first-run guidance, task-oriented documentation, package examples, or the documentation site.
+- **Tests:** Add focused regression coverage, strengthen package-consumer contracts, or extend user-visible black-box journeys.
+- **Features and bug fixes:** Check the [issues list](https://github.com/pmcelhaney/counterfact/issues) and coordinate on the issue before starting a large change.
+
+Coding agents follow a different issue workflow: they must propose new issues through `.github/issue-proposals/` as directed by `AGENTS.md`; they do not create issues directly.
 
 ## Development
 
@@ -21,15 +19,28 @@ the documentation website remain at the root.
 git clone git@github.com:pmcelhaney/counterfact.git
 cd counterfact
 corepack enable
-yarn install
+yarn install --immutable
+yarn build
 yarn lint
+yarn typecheck
 yarn test
 ```
 
-The [code generator](./packages/counterfact/src/typescript-generator/README.md)
-and server runtime are currently part of the `counterfact` workspace. Root
-scripts coordinate builds and checks, so contributors do not need to change
-directories for the standard workflow.
+The root `.mise.toml` and CI use Node 24, while `package.json` is authoritative for the complete supported engine range and pinned Yarn version. Root scripts coordinate builds and checks, so contributors do not need to change directories for the standard workflow.
+
+The repository is organized as focused packages:
+
+- [`@counterfact/types`](./packages/types/README.md) owns dependency-light shared contracts.
+- [`@counterfact/openapi`](./packages/openapi/README.md) owns OpenAPI loading and overlays.
+- [`@counterfact/generator`](./packages/generator/README.md) owns route and type generation.
+- [`@counterfact/runtime`](./packages/runtime/README.md) owns dispatch, registries, hot reload, and adapters.
+- [`@counterfact/client`](./packages/client/README.md) owns immutable request building and raw HTTP requests.
+- [`@counterfact/repl`](./packages/repl/README.md) owns the embeddable terminal experience.
+- [`counterfact`](./packages/counterfact/README.md) remains the product facade, CLI, orchestration layer, and canonical user documentation.
+
+Do not deep-import another workspace's `src/` or `dist/`. Run `yarn check:boundaries` to validate the allowed dependency direction.
+
+Coding agents must also follow [`AGENTS.md`](./AGENTS.md), including the isolated-worktree, pull-request, and repository-learning requirements.
 
 ### Mutation testing
 
@@ -51,6 +62,4 @@ Detailed HTML and JSON reports are written to `reports/mutation/<package>/` and 
 The mutation-testing workflow currently runs on Monday mornings and by manual dispatch rather than as a required pull-request check.
 After two stable full baselines, maintainers can record per-package thresholds and enable the planned no-regression pull-request gate.
 
-Testing and linting changes is important, but at this point I'm more concerned about changing the word "I" in this page to "we", so don't hesitate to create a PR, even it's not "finished".
-
-Thanks in advance!
+Small pull requests are welcome. Explain the observable change, run the checks appropriate to the affected package, and call out any verification that could not be completed locally.

--- a/docs/adr/xxx-package-oriented-monorepo.md
+++ b/docs/adr/xxx-package-oriented-monorepo.md
@@ -2,12 +2,13 @@
 
 ## Status
 
-Implemented (publication pending)
+Implemented and published
 
 The repository migration and release preparation were completed on 2026-08-06.
-Initial npm package creation, trusted-publisher configuration, and publication
-remain explicit maintainer-approved release operations rather than work for the
-migration branch.
+The focused packages have since been published and the `counterfact` facade now
+consumes them through their declared exports. The context below describes the
+pre-migration repository and the constraints that governed the extraction; it
+is historical rather than a description of the current source layout.
 
 ## Context
 

--- a/docs/development/release-bootstrap.md
+++ b/docs/development/release-bootstrap.md
@@ -1,4 +1,4 @@
-# Release bootstrap
+# Release operations
 
 `yarn release:preflight` performs a frozen install under Node 24 with npm
 11.5.1 or newer, then runs package boundaries, exact tarball closures, and
@@ -7,32 +7,30 @@ checking Changesets status. Unpublished versions use `npm publish --dry-run`;
 versions already present on npm use `npm pack --dry-run`. The preflight never
 authenticates or publishes.
 
-Publication remains gated:
+Normal publication is automatic with a manual recovery path:
 
-1. Ordinary pushes to `main` run the ungated prepare job, which creates or
-   updates the Changesets version pull request. Review and merge that pull
-   request before requesting publication.
-2. For the first scoped-package release only, after this migration is merged,
-   a maintainer must explicitly approve npm authentication and initial package
-   creation. From a clean checkout of `main`, run `yarn release:preflight`,
-   then `yarn release` while authenticated as a publisher for the
-   `@counterfact` scope. Changesets skips package versions already present on
-   npm, including the unchanged `counterfact` version, and publishes the six
-   new public workspaces with their manifest-defined public access. Do not
-   store that credential in the repository.
-3. After each package exists, configure its npm trusted publisher for
-   `counterfact/api-simulator` and `.github/workflows/release.yaml`. Verify all
-   six package settings before enabling the workflow environment.
-4. Manually dispatch the Release workflow with `publish` enabled. Its ungated
-   prepare job reruns the full preflight; the downstream publish job is skipped
-   if changesets remain. Approve the `npm-publish` environment only after the
-   preflight and merged version diff pass.
-5. The gated job installs from the frozen lockfile, rebuilds the verified
-   artifacts, and publishes through GitHub OIDC without a long-lived npm
-   token. Lifecycle scripts stay disabled during `npm publish` so each package
-   uses that single release build.
-6. Verify package contents, provenance, and installability on npm before any
-   release announcement. Announcement is a separate, explicit approval.
+1. A qualifying push to `main` runs the prepare job. Pending changesets create
+   or update the Changesets version pull request.
+2. Review and merge that version pull request. Its `changeset version` step is
+   the one intentional lockfile-writing boundary and is followed by
+   `yarn install --mode skip-build --no-immutable` so changed workspace versions
+   are recorded in `yarn.lock`.
+3. A later qualifying push with no pending changesets reruns preflight, installs
+   immutably, rebuilds the verified artifacts, and publishes through GitHub
+   OIDC with provenance.
+4. Use the Release workflow's manual dispatch only to retry or recover
+   publication. It follows the same preflight and immutable-publication path.
+5. Verify package contents, provenance, versions, and installability on npm
+   before any release announcement. Announcement remains a separate action.
 
-The migration branch must not authenticate, create packages, publish, change
-trusted-publisher settings, or announce a release.
+Keep the `npm-publish` environment name, OIDC permission, provenance setting,
+and npm trusted-publisher configuration aligned with
+`.github/workflows/release.yaml`. Never infer that packages were published from
+the preparation job alone; confirm the publish job and registry versions.
+
+## Historical first-release bootstrap
+
+The initial creation of the six `@counterfact` packages and their trusted
+publisher configuration was a one-time maintainer-approved operation completed
+after the package-oriented monorepo migration. It is retained in repository
+history and is not part of the current release procedure.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "yarn": ">=4.5.2"
   },
   "scripts": {
+    "check:agent-guidance": "node scripts/check-agent-guidance.mjs",
     "check:boundaries": "node scripts/check-package-boundaries.mjs",
     "check:publishable": "node scripts/check-publishable.mjs",
     "test": "yarn workspace counterfact test",
+    "test:agent-guidance": "node --test scripts/check-agent-guidance.test.mjs",
     "test:boundaries": "node --test scripts/check-package-boundaries.test.mjs",
     "test:client": "yarn workspace @counterfact/client test",
     "test:client-packed": "yarn workspace @counterfact/client test:packed-consumer",

--- a/scripts/check-agent-guidance.mjs
+++ b/scripts/check-agent-guidance.mjs
@@ -1,0 +1,252 @@
+/*
+ * This repository-only checker intentionally reads paths and patterns declared
+ * by checked-in guidance files rather than accepting external input.
+ */
+/* eslint-disable security/detect-non-literal-fs-filename, security/detect-object-injection, security/detect-non-literal-regexp, security/detect-unsafe-regex */
+import { access, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".yarn",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+  "reports",
+]);
+
+async function exists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectFiles(directory, repositoryRoot, files = []) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(absolutePath, repositoryRoot, files);
+    } else if (entry.isFile()) {
+      files.push(
+        path.relative(repositoryRoot, absolutePath).split(path.sep).join("/"),
+      );
+    }
+  }
+  return files;
+}
+
+export function globToRegularExpression(pattern) {
+  let expression = "^";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === "*" && pattern[index + 1] === "*") {
+      index += 1;
+      if (pattern[index + 1] === "/") {
+        index += 1;
+        expression += "(?:.*/)?";
+      } else {
+        expression += ".*";
+      }
+    } else if (character === "*") {
+      expression += "[^/]*";
+    } else if (character === "?") {
+      expression += "[^/]";
+    } else {
+      expression += character.replace(/[.$()+?[\]^{|}\\]/gu, "\\$&");
+    }
+  }
+  return new RegExp(`${expression}$`, "u");
+}
+
+export function parseApplyTo(source) {
+  const lines = source.split("\n");
+  if (lines[0] !== "---") return [];
+  const endOfFrontmatter = lines.indexOf("---", 1);
+  const applyToIndex = lines.indexOf("applyTo:", 1);
+  if (applyToIndex === -1 || applyToIndex > endOfFrontmatter) return [];
+
+  const patterns = [];
+  for (const line of lines.slice(applyToIndex + 1, endOfFrontmatter)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("- ")) break;
+    const quotedPattern = trimmed.slice(2);
+    const quote = quotedPattern[0];
+    if ((quote === '"' || quote === "'") && quotedPattern.at(-1) === quote) {
+      patterns.push(quotedPattern.slice(1, -1));
+    }
+  }
+  return patterns;
+}
+
+export function parseInspectFirstPaths(source) {
+  const heading = "## Files to inspect first";
+  const headingIndex = source.indexOf(heading);
+  if (headingIndex === -1) return [];
+  const remainder = source.slice(headingIndex + heading.length);
+  const nextHeadingIndex = remainder.search(/^## /mu);
+  const section =
+    nextHeadingIndex === -1 ? remainder : remainder.slice(0, nextHeadingIndex);
+  return [...section.matchAll(/^- `(?<target>[^`]+)`(?: .*)?$/gmu)].map(
+    (match) => match.groups.target,
+  );
+}
+
+export function parseYarnScripts(source) {
+  return [...source.matchAll(/`yarn (?<script>[a-z][\w:-]*)/gu)].map(
+    (match) => match.groups.script,
+  );
+}
+
+export function parseLocalMarkdownLinks(source) {
+  return [...source.matchAll(/\]\((?<target>[^)\s]+)(?:\s+"[^"]*")?\)/gu)]
+    .map((match) => match.groups.target.replace(/^<|>$/gu, ""))
+    .filter(
+      (target) =>
+        !target.startsWith("#") &&
+        !target.startsWith("http://") &&
+        !target.startsWith("https://") &&
+        !target.startsWith("mailto:"),
+    );
+}
+
+export async function validateAgentGuidance(repositoryRoot) {
+  const errors = [];
+  const files = await collectFiles(repositoryRoot, repositoryRoot);
+  const packageJson = JSON.parse(
+    await readFile(path.join(repositoryRoot, "package.json"), "utf8"),
+  );
+  const rootCommands = new Set([
+    ...Object.keys(packageJson.scripts ?? {}),
+    "eslint",
+    "install",
+    "workspace",
+  ]);
+  const skillsRoot = path.join(repositoryRoot, ".github", "skills");
+  const skillFiles = (await collectFiles(skillsRoot, repositoryRoot)).filter(
+    (file) => file.endsWith("/SKILL.md"),
+  );
+
+  const agentsSource = await readFile(
+    path.join(repositoryRoot, "AGENTS.md"),
+    "utf8",
+  );
+  const listedSkills = [
+    ...agentsSource.matchAll(
+      /^- `(?<target>\.github\/skills\/[^`]+\/SKILL\.md)`$/gmu,
+    ),
+  ].map((match) => match.groups.target);
+
+  for (const skillFile of skillFiles) {
+    if (!listedSkills.includes(skillFile)) {
+      errors.push(`${skillFile}: skill is not listed in AGENTS.md`);
+    }
+
+    const source = await readFile(path.join(repositoryRoot, skillFile), "utf8");
+    const patterns = parseApplyTo(source);
+    if (patterns.length === 0) {
+      errors.push(`${skillFile}: applyTo must contain at least one pattern`);
+    }
+    for (const pattern of patterns) {
+      const matcher = globToRegularExpression(pattern);
+      if (!files.some((file) => matcher.test(file))) {
+        errors.push(
+          `${skillFile}: applyTo pattern matches no files: ${pattern}`,
+        );
+      }
+    }
+
+    for (const target of parseInspectFirstPaths(source)) {
+      if (!(await exists(path.join(repositoryRoot, target)))) {
+        errors.push(
+          `${skillFile}: inspect-first path does not exist: ${target}`,
+        );
+      }
+    }
+
+    for (const script of parseYarnScripts(source)) {
+      if (!rootCommands.has(script)) {
+        errors.push(`${skillFile}: unknown root Yarn command: ${script}`);
+      }
+    }
+  }
+
+  for (const listedSkill of listedSkills) {
+    if (!skillFiles.includes(listedSkill)) {
+      errors.push(`AGENTS.md: listed skill does not exist: ${listedSkill}`);
+    }
+  }
+
+  const linkSources = [
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    ...skillFiles,
+  ];
+  for (const sourceFile of linkSources) {
+    const absoluteSource = path.join(repositoryRoot, sourceFile);
+    if (!(await exists(absoluteSource))) continue;
+    const source = await readFile(absoluteSource, "utf8");
+    for (const link of parseLocalMarkdownLinks(source)) {
+      const target = decodeURIComponent(link.split("#", 1)[0]);
+      const absoluteTarget = path.resolve(path.dirname(absoluteSource), target);
+      if (!(await exists(absoluteTarget))) {
+        errors.push(`${sourceFile}: local link does not exist: ${link}`);
+      }
+    }
+  }
+
+  const rootReadme = await readFile(
+    path.join(repositoryRoot, "README.md"),
+    "utf8",
+  );
+  const packageDirectories = files
+    .filter((file) => /^packages\/[^/]+\/package\.json$/u.test(file))
+    .map((file) => file.split("/")[1]);
+  for (const packageDirectory of packageDirectories) {
+    const readmeLink = `./packages/${packageDirectory}/README.md`;
+    if (!rootReadme.includes(readmeLink)) {
+      errors.push(
+        `README.md: workspace is missing from package map: ${packageDirectory}`,
+      );
+    }
+  }
+
+  const pullRequestTemplate = await readFile(
+    path.join(repositoryRoot, ".github", "pull_request_template.md"),
+    "utf8",
+  );
+  for (const heading of [
+    "## Manual acceptance tests",
+    "## Repository learning check",
+  ]) {
+    if (!pullRequestTemplate.includes(heading)) {
+      errors.push(`.github/pull_request_template.md: missing ${heading}`);
+    }
+  }
+
+  return errors;
+}
+
+async function main() {
+  const repositoryRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const errors = await validateAgentGuidance(repositoryRoot);
+  if (errors.length > 0) {
+    console.error(errors.join("\n"));
+    process.exitCode = 1;
+    return;
+  }
+  console.log("Agent guidance is internally consistent.");
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/check-agent-guidance.test.mjs
+++ b/scripts/check-agent-guidance.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { usingTemporaryFiles } from "using-temporary-files";
+
+import {
+  globToRegularExpression,
+  parseApplyTo,
+  parseInspectFirstPaths,
+  parseLocalMarkdownLinks,
+  validateAgentGuidance,
+} from "./check-agent-guidance.mjs";
+
+const VALID_SKILL = `---
+name: example
+description: Example skill.
+applyTo:
+  - "packages/example/src/**/*.ts"
+---
+
+# Example
+
+## Files to inspect first
+
+- \`packages/example/README.md\`
+
+## How to validate the change
+
+- Run \`yarn test\`.
+`;
+
+async function addValidRepository($) {
+  await $.add(
+    "package.json",
+    `${JSON.stringify({ scripts: { test: "node --test" } })}\n`,
+  );
+  await $.add("AGENTS.md", "- `.github/skills/example/SKILL.md`\n");
+  await $.add(".github/skills/example/SKILL.md", VALID_SKILL);
+  await $.add(
+    ".github/pull_request_template.md",
+    "## Manual acceptance tests\n\n## Repository learning check\n",
+  );
+  await $.add("packages/example/README.md", "# Example\n");
+  await $.add("README.md", "[`example`](./packages/example/README.md)\n");
+  await $.add("packages/example/src/index.ts", "export {};\n");
+}
+
+test("matches the skill glob forms used by the repository", () => {
+  assert.equal(
+    globToRegularExpression("packages/*/src/**/*.ts").test(
+      "packages/runtime/src/server/dispatcher.ts",
+    ),
+    true,
+  );
+  assert.equal(
+    globToRegularExpression("packages/*/src/**/*.ts").test(
+      "packages/runtime/test/dispatcher.test.ts",
+    ),
+    false,
+  );
+});
+
+test("parses applicability and inspect-first paths", () => {
+  assert.deepEqual(parseApplyTo(VALID_SKILL), ["packages/example/src/**/*.ts"]);
+  assert.deepEqual(parseInspectFirstPaths(VALID_SKILL), [
+    "packages/example/README.md",
+  ]);
+  assert.deepEqual(
+    parseLocalMarkdownLinks(
+      "[local](./local.md) [anchor](#here) [remote](https://example.com)",
+    ),
+    ["./local.md"],
+  );
+});
+
+test("accepts consistent repository guidance", async () => {
+  await usingTemporaryFiles(async ($) => {
+    await addValidRepository($);
+    assert.deepEqual(await validateAgentGuidance($.path(".")), []);
+  });
+});
+
+test("reports stale paths, patterns, commands, links, and templates", async () => {
+  await usingTemporaryFiles(async ($) => {
+    await addValidRepository($);
+    await $.add(
+      ".github/skills/example/SKILL.md",
+      VALID_SKILL.replace(
+        '  - "packages/example/src/**/*.ts"',
+        '  - "packages/missing/**/*.ts"',
+      )
+        .replace("packages/example/README.md", "packages/missing/README.md")
+        .replace("yarn test", "yarn missing:script"),
+    );
+    await $.add(
+      ".github/pull_request_template.md",
+      "## Manual acceptance tests\n",
+    );
+    await $.add(
+      "CONTRIBUTING.md",
+      "[Missing contribution guide](./docs/missing.md)\n",
+    );
+
+    const errors = await validateAgentGuidance($.path("."));
+    assert.ok(errors.some((error) => error.includes("matches no files")));
+    assert.ok(errors.some((error) => error.includes("does not exist")));
+    assert.ok(
+      errors.some((error) => error.includes("unknown root Yarn command")),
+    );
+    assert.ok(
+      errors.some((error) => error.includes("Repository learning check")),
+    );
+    assert.ok(
+      errors.some((error) => error.includes("local link does not exist")),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- align the canonical agent skills and contributor guidance with the package-oriented monorepo
- add focused OpenAPI and client/REPL skills plus package-aware verification guidance
- add a tested CI check for stale skill paths, applicability patterns, local links, root commands, workspace coverage, and required PR sections
- mark migration-only release instructions as historical while documenting the current automatic publication and recovery flow

The devcontainer implementation remains isolated in #2358 and is intentionally not duplicated here.

## Manual acceptance tests

- [ ] Read the repository-basics skill and confirm that every current Counterfact workspace is described with its actual responsibility.
- [ ] Follow each skill's inspect-first links and confirm that they open current files rather than removed pre-monorepo paths.
- [ ] Change an inspect-first path or applicability pattern to a nonexistent target and confirm the agent-guidance check reports the stale reference.
- [ ] Open a new pull request and confirm the default template contains unchecked observable acceptance tests and the repository learning check.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): .github/skills/counterfact-maintenance/SKILL.md
- Rationale: Build-producing verification must run sequentially because concurrent workspace builds remove and recreate shared dist directories and can invalidate one another's outputs.

## Tasks

- update canonical skills, AGENTS.md, CONTRIBUTING.md, and release documentation
- add guidance integrity validation, tests, root scripts, and CI execution
- clarify filesystem-test and manual-acceptance lifecycle exceptions

## Verification

- immutable Yarn 4.18 install under Node 24.19
- agent guidance check and 4 focused checker tests
- Prettier and ESLint
- build and typecheck
- package boundary tests and boundary validation
- 64 unit suites: 942 tests and 127 snapshots
- packed-consumer and all seven exact package closures
- TSD type tests
- all five product black-box journeys passed across sequential local runs

No changeset is included because this changes repository guidance and CI validation without changing a published package or user-facing product behavior.
