### PR TITLE
Fix OpenAPI watch input classification and overlay hot reload

### DIFF
--- a/.changeset/fair-spoons-watch.md
+++ b/.changeset/fair-spoons-watch.md
@@ -1,0 +1,7 @@
+---
+"@counterfact/openapi": patch
+"@counterfact/generator": patch
+"@counterfact/runtime": patch
+---
+
+Classify OpenAPI sources consistently and hot-reload local base documents and overlays without mistaking local `http`-prefixed paths for remote URLs.

--- a/.github/skills/counterfact-generator-internals/SKILL.md
+++ b/.github/skills/counterfact-generator-internals/SKILL.md
@@ -31,6 +31,7 @@ Use this skill when changing OpenAPI loading/bundling, schema-to-type generation
 - Preserve regeneration contract: existing route files are not overwritten; generated types are overwritten.
 - Support OpenAPI features through typed coders and requirement traversal rather than ad-hoc string logic.
 - Keep generated output deterministic and formatted via existing script/repository pipeline.
+- Build generator watch sets through `@counterfact/openapi` source classification: watch every unique local contributing input (base document plus overlays), exclude remote inputs and `_`, and regenerate from the complete ordered input set after any change. Do not infer URL-ness from a string prefix.
 
 ## Common mistakes to avoid
 

--- a/packages/counterfact/docs/faq.md
+++ b/packages/counterfact/docs/faq.md
@@ -302,7 +302,13 @@ No. Counterfact watches the routes directory and hot-reloads changed files immed
 
 ## When do I need to restart?
 
-If your OpenAPI spec is a remote URL, Counterfact only fetches it once at startup. To pick up spec changes you need to restart (or use a local copy and `--watch`). If your spec is a local file, Counterfact watches it and regenerates types automatically — no restart required.
+Counterfact watches every local file that contributes to the OpenAPI document,
+including the base spec and ordered overlays. Editing any of those files
+reloads the complete composed document and regenerates enabled artifacts, so no
+restart is required. HTTP(S) inputs are loaded at startup but are not watched;
+restart to pick up a remote-only change. If a remote base uses a local overlay,
+editing that overlay triggers a fresh load of the remote base before all
+overlays are reapplied.
 
 ---
 

--- a/packages/counterfact/docs/reference.md
+++ b/packages/counterfact/docs/reference.md
@@ -262,6 +262,13 @@ Store reloads update prototype methods and add new enumerable fields without
 overwriting existing state. A broken or deleted store source leaves the last
 good live object in place.
 
+When OpenAPI watching is enabled, Counterfact also watches every local input
+that contributes to the composed contract: the base document and each local
+overlay. Saving any of them reloads the complete base-plus-overlay document and
+regenerates the enabled artifacts. HTTP(S) inputs are loaded at startup but are
+not watched; a local overlay remains watchable even when the base document is
+remote.
+
 No restart required.
 
 ---
@@ -445,6 +452,10 @@ Pass `--overlay` one or more times. Overlays are applied in the order they appea
 ```bash
 npx counterfact@latest openapi.yaml ./out --overlay base-overlay.yaml --overlay env-overlay.yaml
 ```
+
+With `--watch`, changes to any local overlay reapply the complete ordered
+overlay chain and update the running server. Remote HTTP(S) overlays are not
+polled or watched.
 
 ### Programmatic usage
 

--- a/packages/generator/src/code-generator.ts
+++ b/packages/generator/src/code-generator.ts
@@ -5,6 +5,7 @@ import nodePath from "node:path";
 
 import { type FSWatcher, watch } from "chokidar";
 import createDebug from "debug";
+import { getLocalOpenApiSourcePaths } from "@counterfact/openapi";
 
 import { ensureDirectoryExists } from "./ensure-directory-exists.js";
 import { OperationCoder } from "./operation-coder.js";
@@ -247,9 +248,10 @@ export class CodeGenerator extends EventTarget {
    * Resolves once the watcher is ready.
    */
   public async watch() {
-    const watchablePaths = this.openapiPath.startsWith("http")
-      ? [...this.overlays]
-      : [this.openapiPath, ...this.overlays];
+    const watchablePaths = getLocalOpenApiSourcePaths([
+      this.openapiPath,
+      ...this.overlays,
+    ]);
 
     if (watchablePaths.length === 0) {
       return;

--- a/packages/generator/test/code-generator.test.ts
+++ b/packages/generator/test/code-generator.test.ts
@@ -101,7 +101,7 @@ describe("a CodeGenerator", () => {
         { routes: true, types: true },
       );
 
-      const changed = { ...OPENAPI };
+      const changed = structuredClone(OPENAPI);
 
       changed.components.schemas.Example.type = "integer";
 
@@ -150,6 +150,37 @@ describe("a CodeGenerator", () => {
     });
   });
 
+  it("watches a local relative path that begins with 'http'", async () => {
+    await usingTemporaryFiles(async ({ add, path, read }) => {
+      await add("httpspec.json", JSON.stringify(OPENAPI));
+      const originalWorkingDirectory = process.cwd();
+      process.chdir(path("."));
+
+      try {
+        const generator = new CodeGenerator("httpspec.json", path("./out"), {
+          routes: true,
+          types: true,
+        });
+        const changed = structuredClone(OPENAPI);
+        changed.components.schemas.Example.type = "integer";
+
+        await generator.watch();
+        await add("httpspec.json", JSON.stringify(changed));
+        await waitForEvent(generator, "generate");
+
+        const exampleComponent = await read(
+          "./out/types/components/schemas/Example.ts",
+        );
+
+        await generator.stopWatching();
+
+        expect(exampleComponent).toContain("export type Example = number;\n");
+      } finally {
+        process.chdir(originalWorkingDirectory);
+      }
+    });
+  });
+
   it("does not update the code when the spec changes if watch is false", async () => {
     await usingTemporaryFiles(async ({ add, path, read }) => {
       await add("openapi.json", JSON.stringify(OPENAPI));
@@ -160,7 +191,7 @@ describe("a CodeGenerator", () => {
         { routes: true, types: false },
       );
 
-      const changed = { ...OPENAPI };
+      const changed = structuredClone(OPENAPI);
 
       changed.components.schemas.Example.type = "integer";
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -24,5 +24,10 @@ void bundled;
 one document while retaining internal references. Overlay paths are applied in
 the order provided.
 
+`classifyOpenApiSource` distinguishes local inputs from parsed HTTP(S) URLs,
+and `getLocalOpenApiSourcePaths` returns unique local watcher inputs while
+excluding remote URLs and Counterfact's `_` sentinel. File URLs are normalized
+to local paths; ordinary file names such as `httpspec.yaml` remain local.
+
 See [`examples/load-local-spec.mjs`](./examples/load-local-spec.mjs) for a
 complete public-import example.

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -10,4 +10,9 @@ export {
   loadOpenApiDocument,
   type OpenApiDocument,
 } from "./load-openapi-document.js";
+export {
+  classifyOpenApiSource,
+  getLocalOpenApiSourcePaths,
+  type OpenApiSource,
+} from "./openapi-source.js";
 export { readFile } from "./read-file.js";

--- a/packages/openapi/src/openapi-source.ts
+++ b/packages/openapi/src/openapi-source.ts
@@ -1,0 +1,55 @@
+import nodePath from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type OpenApiSource =
+  { kind: "local"; path: string } | { kind: "remote"; url: URL };
+
+/**
+ * Classifies an OpenAPI input as a local file-system path or a remote URL.
+ *
+ * Only successfully parsed HTTP(S) URLs are remote. File URLs are converted
+ * to file-system paths, and every other input is treated as an ordinary local
+ * path. NUL bytes are rejected before either classification can occur.
+ */
+export function classifyOpenApiSource(source: string): OpenApiSource {
+  if (source.includes("\0")) {
+    throw new Error("File path cannot contain NUL bytes.");
+  }
+
+  let url: URL | undefined;
+
+  try {
+    url = new URL(source);
+  } catch {
+    // Ordinary local paths do not need to be valid URLs.
+  }
+
+  if (url?.protocol === "http:" || url?.protocol === "https:") {
+    return { kind: "remote", url };
+  }
+
+  if (url?.protocol === "file:") {
+    return { kind: "local", path: fileURLToPath(url) };
+  }
+
+  return { kind: "local", path: nodePath.resolve(source) };
+}
+
+/** Returns the unique local paths from a list of OpenAPI inputs. */
+export function getLocalOpenApiSourcePaths(
+  sources: readonly string[],
+): string[] {
+  return [
+    ...new Set(
+      sources.flatMap((source) => {
+        if (source === "_") {
+          return [];
+        }
+
+        const classified = classifyOpenApiSource(source);
+
+        return classified.kind === "local" ? [classified.path] : [];
+      }),
+    ),
+  ];
+}

--- a/packages/openapi/src/read-file.ts
+++ b/packages/openapi/src/read-file.ts
@@ -1,33 +1,8 @@
 import fs from "node:fs/promises";
-import nodePath from "node:path";
 
 import nodeFetch from "node-fetch";
 
-function normalizeLocalPath(path: string): string {
-  if (path.includes("\0")) {
-    throw new Error("File path cannot contain NUL bytes.");
-  }
-
-  return nodePath.resolve(path);
-}
-
-function parseSupportedUrl(urlOrPath: string): URL | undefined {
-  try {
-    const url = new URL(urlOrPath);
-
-    if (
-      url.protocol === "file:" ||
-      url.protocol === "http:" ||
-      url.protocol === "https:"
-    ) {
-      return url;
-    }
-  } catch {
-    // A local path is not necessarily a valid URL.
-  }
-
-  return undefined;
-}
+import { classifyOpenApiSource } from "./openapi-source.js";
 
 /**
  * Reads the content of a file or URL and returns it as a UTF-8 string.
@@ -41,24 +16,14 @@ function parseSupportedUrl(urlOrPath: string): URL | undefined {
  * @returns The file contents as a string.
  */
 export async function readFile(urlOrPath: string) {
-  if (urlOrPath.includes("\0")) {
-    throw new Error("File path cannot contain NUL bytes.");
-  }
+  const source = classifyOpenApiSource(urlOrPath);
 
-  const url = parseSupportedUrl(urlOrPath);
-
-  if (url?.protocol === "http:" || url?.protocol === "https:") {
-    const response = await nodeFetch(urlOrPath);
+  if (source.kind === "remote") {
+    const response = await nodeFetch(source.url);
 
     return await response.text();
   }
 
-  if (url?.protocol === "file:") {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- file URL is parsed and protocol-validated immediately above.
-    return await fs.readFile(url, "utf8");
-  }
-
-  const normalizedPath = normalizeLocalPath(urlOrPath);
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is normalized and NUL-byte validated before filesystem access.
-  return await fs.readFile(normalizedPath, "utf8");
+  return await fs.readFile(source.path, "utf8");
 }

--- a/packages/openapi/test/openapi-source.test.ts
+++ b/packages/openapi/test/openapi-source.test.ts
@@ -1,0 +1,69 @@
+import nodePath from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "@jest/globals";
+import { usingTemporaryFiles } from "using-temporary-files";
+
+import {
+  classifyOpenApiSource,
+  getLocalOpenApiSourcePaths,
+} from "../src/index.js";
+
+describe("OpenAPI source classification", () => {
+  it("classifies parsed HTTP(S) URLs as remote", () => {
+    expect(
+      classifyOpenApiSource("http://example.com/openapi.yaml"),
+    ).toMatchObject({ kind: "remote" });
+    expect(
+      classifyOpenApiSource("https://example.com/openapi.yaml"),
+    ).toMatchObject({ kind: "remote" });
+  });
+
+  it("classifies ordinary paths beginning with URL scheme names as local", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const originalWorkingDirectory = process.cwd();
+      process.chdir($.path("."));
+
+      try {
+        expect(classifyOpenApiSource("httpspec.yaml")).toStrictEqual({
+          kind: "local",
+          path: nodePath.resolve("httpspec.yaml"),
+        });
+      } finally {
+        process.chdir(originalWorkingDirectory);
+      }
+    });
+  });
+
+  it("converts file URLs to local paths", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const path = $.path("openapi.yaml");
+
+      expect(classifyOpenApiSource(pathToFileURL(path).href)).toStrictEqual({
+        kind: "local",
+        path,
+      });
+    });
+  });
+
+  it("returns unique local contributing inputs and preserves '_'", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const path = $.path("overlay.yaml");
+
+      expect(
+        getLocalOpenApiSourcePaths([
+          "_",
+          "https://example.com/openapi.yaml",
+          path,
+          pathToFileURL(path).href,
+        ]),
+      ).toStrictEqual([path]);
+    });
+  });
+
+  it("rejects NUL bytes", () => {
+    expect(() => classifyOpenApiSource("bad\0path.yaml")).toThrow(
+      "File path cannot contain NUL bytes.",
+    );
+  });
+});

--- a/packages/runtime/src/server/openapi-document.ts
+++ b/packages/runtime/src/server/openapi-document.ts
@@ -1,6 +1,9 @@
 import { type FSWatcher, watch } from "chokidar";
 import createDebug from "debug";
-import { loadOpenApiDocument as loadOpenApiData } from "@counterfact/openapi";
+import {
+  getLocalOpenApiSourcePaths,
+  loadOpenApiDocument as loadOpenApiData,
+} from "@counterfact/openapi";
 import type { OpenApiOperation } from "@counterfact/types";
 import type { RuntimeEventReporter } from "../runtime-config.js";
 import { waitForEvent } from "../util/wait-for-event.js";
@@ -104,17 +107,23 @@ export class OpenApiDocument extends EventTarget {
   }
 
   /**
-   * Starts watching the source file for changes. When a change is detected
-   * the document reloads itself and dispatches a `"reload"` event.
+   * Starts watching every local input for changes. When a change is detected
+   * the complete base document and overlay chain are reloaded before a
+   * `"reload"` event is dispatched.
    *
-   * Has no effect when the source is `"_"` or a remote URL.
+   * Has no effect when none of the contributing inputs is local.
    */
   public async watch(): Promise<void> {
-    if (this.source === "_" || this.source.startsWith("http")) {
+    const watchablePaths = getLocalOpenApiSourcePaths([
+      this.source,
+      ...this.overlays,
+    ]);
+
+    if (watchablePaths.length === 0) {
       return;
     }
 
-    this.watcher = watch(this.source, CHOKIDAR_OPTIONS).on("change", () => {
+    this.watcher = watch(watchablePaths, CHOKIDAR_OPTIONS).on("change", () => {
       this.reportEvent("file_change_detected", {
         changeType: "change",
         fileType: "openapi",

--- a/packages/runtime/src/server/openapi-watcher.ts
+++ b/packages/runtime/src/server/openapi-watcher.ts
@@ -1,5 +1,6 @@
 import { type FSWatcher, watch } from "chokidar";
 import createDebug from "debug";
+import { getLocalOpenApiSourcePaths } from "@counterfact/openapi";
 
 import { waitForEvent } from "../util/wait-for-event.js";
 import { CHOKIDAR_OPTIONS } from "./constants.js";
@@ -21,29 +22,28 @@ export class OpenApiWatcher {
   }
 
   public async watch(): Promise<void> {
-    if (this.openApiPath === "_" || this.openApiPath.startsWith("http")) {
+    const [watchablePath] = getLocalOpenApiSourcePaths([this.openApiPath]);
+
+    if (watchablePath === undefined) {
       return;
     }
 
-    this.watcher = watch(this.openApiPath, CHOKIDAR_OPTIONS).on(
-      "change",
-      () => {
-        void (async () => {
-          try {
-            this.dispatcher.openApiDocument = await loadOpenApiDocument(
-              this.openApiPath,
-            );
-            debug("reloaded OpenAPI document from %s", this.openApiPath);
-          } catch (error: unknown) {
-            debug(
-              "failed to reload OpenAPI document from %s: %o",
-              this.openApiPath,
-              error,
-            );
-          }
-        })();
-      },
-    );
+    this.watcher = watch(watchablePath, CHOKIDAR_OPTIONS).on("change", () => {
+      void (async () => {
+        try {
+          this.dispatcher.openApiDocument = await loadOpenApiDocument(
+            this.openApiPath,
+          );
+          debug("reloaded OpenAPI document from %s", this.openApiPath);
+        } catch (error: unknown) {
+          debug(
+            "failed to reload OpenAPI document from %s: %o",
+            this.openApiPath,
+            error,
+          );
+        }
+      })();
+    });
 
     await waitForEvent(this.watcher, "ready");
   }

--- a/packages/runtime/test/server/openapi-document.test.ts
+++ b/packages/runtime/test/server/openapi-document.test.ts
@@ -141,6 +141,84 @@ describe("OpenApiDocument", () => {
     });
   });
 
+  it("reloads the complete document when a local overlay changes", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("openapi.json", JSON.stringify(OPENAPI));
+      await $.add(
+        "overlay.json",
+        JSON.stringify({
+          overlay: "1.0.0",
+          actions: [
+            {
+              target: "$.paths['/example'].get.responses['200']",
+              update: { description: "Initial overlay" },
+            },
+          ],
+        }),
+      );
+
+      const doc = new OpenApiDocument($.path("openapi.json"), [
+        $.path("overlay.json"),
+      ]);
+
+      await doc.load();
+      await doc.watch();
+
+      await $.add(
+        "overlay.json",
+        JSON.stringify({
+          overlay: "1.0.0",
+          actions: [
+            {
+              target: "$.paths['/example'].get.responses['200']",
+              update: { description: "Reloaded overlay" },
+            },
+          ],
+        }),
+      );
+
+      await waitForEvent(doc, "reload");
+      await doc.stopWatching();
+
+      expect(doc.paths["/example"]?.get?.responses?.["200"]?.description).toBe(
+        "Reloaded overlay",
+      );
+    });
+  });
+
+  it("watches a local relative path that begins with 'http'", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("httpspec.json", JSON.stringify(OPENAPI));
+      const originalWorkingDirectory = process.cwd();
+      process.chdir($.path("."));
+
+      try {
+        const doc = new OpenApiDocument("httpspec.json");
+        await doc.load();
+        await doc.watch();
+
+        await $.add(
+          "httpspec.json",
+          JSON.stringify({
+            ...OPENAPI,
+            paths: {
+              "/http-prefix-reloaded": {
+                get: { responses: { "200": { description: "OK" } } },
+              },
+            },
+          }),
+        );
+
+        await waitForEvent(doc, "reload");
+        await doc.stopWatching();
+
+        expect(Object.keys(doc.paths)).toStrictEqual(["/http-prefix-reloaded"]);
+      } finally {
+        process.chdir(originalWorkingDirectory);
+      }
+    });
+  });
+
   it("does not watch when source is '_'", async () => {
     const doc = new OpenApiDocument("_");
 

--- a/test-black-box/features/contract_evolution.feature
+++ b/test-black-box/features/contract_evolution.feature
@@ -9,6 +9,8 @@ Feature: Evolve a contract without stale behavior
     Then the external schema drives generated types and a deterministic response
     And the last overlay update wins
     And the overlay-removed route has no generated artifact
+    When I change a response example in the final overlay
+    Then the live server returns the changed overlay example
     When I change an existing response example in the source contract
     Then the live server returns the changed example
     When I remove the obsolete operation and regenerate with prune

--- a/test-black-box/test_contract_evolution_journey.py
+++ b/test-black-box/test_contract_evolution_journey.py
@@ -90,16 +90,16 @@ def write_ordered_overlays(journey):
             ],
         },
     )
+    journey.second_overlay_document = {
+        "overlay": "1.0.0",
+        "info": {"title": "Second", "version": "1.0.0"},
+        "actions": [
+            {"target": GREETING_TARGET, "update": {"value": "second"}},
+            {"target": "$.paths['/removed-by-overlay']", "remove": True},
+        ],
+    }
     journey.second_overlay = journey.write_json(
-        "second-overlay.json",
-        {
-            "overlay": "1.0.0",
-            "info": {"title": "Second", "version": "1.0.0"},
-            "actions": [
-                {"target": GREETING_TARGET, "update": {"value": "second"}},
-                {"target": "$.paths['/removed-by-overlay']", "remove": True},
-            ],
-        },
+        "second-overlay.json", journey.second_overlay_document
     )
 
 
@@ -144,6 +144,25 @@ def last_overlay_wins(journey):
 def removed_overlay_route_is_omitted(journey):
     assert not (journey.output / "routes" / "removed-by-overlay.ts").exists()
     assert journey.request("get", "/removed-by-overlay").status_code == 404
+
+
+@when("I change a response example in the final overlay")
+def change_final_overlay_example(journey):
+    journey.second_overlay_document["actions"][0]["update"]["value"] = (
+        "overlay-reloaded"
+    )
+    journey.write_json("second-overlay.json", journey.second_overlay_document)
+
+
+@then("the live server returns the changed overlay example")
+def live_server_uses_changed_overlay(journey):
+    response = journey.wait_for_http(
+        "/greeting",
+        lambda candidate: (
+            candidate.status_code == 200 and candidate.text == "overlay-reloaded"
+        ),
+    )
+    assert response.text == "overlay-reloaded"
 
 
 @when("I change an existing response example in the source contract")


### PR DESCRIPTION
## Summary

- add a shared `@counterfact/openapi` source classifier that recognizes parsed HTTP(S) URLs, converts `file:` URLs to local paths, preserves NUL rejection, and keeps ordinary names such as `httpspec.yaml` local
- make runtime and generator watchers observe every unique local OpenAPI input, including ordered overlays, while excluding remote inputs and the `_` sentinel
- reload the complete base-plus-overlay document when any local contributor changes, and document the resulting watch behavior
- extend the existing contract-evolution journey to prove that editing a local overlay updates the live server without a restart
- add patch changesets for `@counterfact/openapi`, `@counterfact/generator`, and `@counterfact/runtime`

## Verification

- focused OpenAPI, runtime, and generator tests: 4 suites, 26 tests passed
- full unit suite: 65 suites, 950 tests, and 127 snapshots passed
- build, typecheck, and lint passed
- focused contract-evolution black-box journey passed
- release preflight passed, including package boundaries, packaging dry runs, isolated package closures, and changeset validation

## Manual acceptance tests

- [x] Start Counterfact with a local base document, a local overlay, `--watch`, and `--serve`; edit the overlay and confirm the affected endpoint changes without restarting the process.
- [x] Start Counterfact from a local file named `httpspec.yaml`; edit the file and confirm generated contracts and the running server reflect the change.
- [x] Use the `_` spec sentinel in a configuration that generates scenario/context artifacts and confirm Counterfact does not attempt to watch a file literally named `_`.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): `.github/skills/counterfact-generator-internals/SKILL.md`
- Rationale: Generator watchers must classify sources through the shared OpenAPI contract, watch every unique local contributor, and regenerate from the complete ordered input set instead of inferring URL behavior from string prefixes.
