### PR TITLE
docs: clarify agent-created PR guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,9 @@
 
 </details>
 
-## Manual acceptance tests
+## Agent-created PR notes
 
-<!-- Agent: replace this section with 3–6 unchecked checkboxes per AGENTS.md. Each must describe an observable behavior. -->
+<!-- Agent opening this PR: add the Manual acceptance tests section and, for non-trivial work, the Repository learning check from counterfact-pr-creation. These are agent-PR-author responsibilities, not review requirements; reviewers must not look for them when they are absent. -->
 
 ## Tasks
 

--- a/.github/skills/counterfact-maintenance/SKILL.md
+++ b/.github/skills/counterfact-maintenance/SKILL.md
@@ -127,4 +127,3 @@ Keep that operating-system skip scoped to the real-terminal scenario so non-inte
 - Run targeted tests for touched modules before full test run.
 - If server startup or CLI behavior changed, run `yarn build` then `yarn test:black-box`.
 - For black-box changes, run the boundary searches above and resolve or explicitly reclassify every finding in the touched scope.
-- Ensure PR notes include manual acceptance tests with observable outcomes.

--- a/.github/skills/counterfact-pr-creation/SKILL.md
+++ b/.github/skills/counterfact-pr-creation/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: counterfact-pr-creation
+description: Create Counterfact pull requests with the required agent-authored acceptance and repository-learning notes; do not use to review another PR.
+---
+
+# Counterfact PR Creation Skill
+
+## When to use this skill
+
+Use this skill when an agent creates or opens a Counterfact pull request.
+Do not use it as a review checklist.
+
+## Agent-owned PR sections
+
+`## Manual acceptance tests` and `## Repository learning check` are responsibilities of the agent that creates the PR, not of a reviewing agent.
+A reviewing agent must not look for either section or treat its absence as a PR deficiency.
+Their absence most likely means the PR was not opened by an agent.
+
+## Manual acceptance tests
+
+Every agent-created PR description must include a section titled exactly `## Manual acceptance tests` with 3–6 unchecked checkboxes.
+Each checkbox must describe an observable behavior, not an implementation detail, and must not be pre-checked.
+
+- Cover the main success path, at least one edge case, and one regression check where applicable.
+- A PR that only adds files under `.github/issue-proposals/` may omit this section.
+- The repository workflow validates this section for applicable PRs; complete the checklist before merge.
+
+## Repository learning check
+
+For every non-trivial agent-created PR, include this section in the PR description:
+
+```markdown
+## Repository learning check
+
+- Learning found: Yes/No
+- Guidance updated: Yes/No
+- Updated file(s): N/A or list files
+- Rationale: one sentence explaining why the repository guidance did or did not need to change
+```
+
+If `Learning found: Yes`, update the most relevant repository guidance in the same PR.
+
+Use the following decision tree:
+
+- Runtime behavior, REPL behavior, request handling, context usage, server lifecycle, or application architecture → update the appropriate `SKILL.md`
+- Generator behavior, code generation patterns, route generation, OpenAPI processing, overlays, or specification handling → update the appropriate `SKILL.md`
+- Build, test, release, CI/CD, dependency management, repository maintenance, or contributor workflow → update the appropriate `SKILL.md`
+- Cross-cutting conventions that apply throughout the repository → update `AGENTS.md`
+
+A durable learning is a reusable rule, pattern, validation step, compatibility concern, testing strategy, architectural constraint, or repository-specific convention that helps future contributors avoid mistakes or work more effectively.
+
+Do not create guidance for one-off implementation details, temporary workarounds, PR-specific decisions, historical commentary, or task summaries.
+If no durable learning was discovered, explicitly record `Learning found: No` and do not create or modify guidance files solely to satisfy this requirement.

--- a/.github/skills/counterfact-pr-creation/SKILL.md
+++ b/.github/skills/counterfact-pr-creation/SKILL.md
@@ -22,8 +22,8 @@ Their absence most likely means the PR was not opened by an agent.
 
 ## Manual acceptance tests
 
-Every agent-created PR description must include a section titled exactly `## Manual acceptance tests` with 3–6 unchecked checkboxes.
-Each checkbox must describe an observable behavior, not an implementation detail, and must not be pre-checked.
+Every agent-created PR description must include a section titled exactly `## Manual acceptance tests` with 3–6 checklist items that start unchecked.
+Each checklist item must describe an observable behavior, not an implementation detail; complete the items before merge.
 
 - Cover the main success path, at least one edge case, and one regression check where applicable.
 - A PR that only adds files under `.github/issue-proposals/` may omit this section.

--- a/.github/skills/counterfact-pr-creation/SKILL.md
+++ b/.github/skills/counterfact-pr-creation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: counterfact-pr-creation
 description: Create Counterfact pull requests with the required agent-authored acceptance and repository-learning notes; do not use to review another PR.
+applyTo:
+  - ".github/pull_request_template.md"
+  - ".github/skills/**/*.md"
+  - "AGENTS.md"
 ---
 
 # Counterfact PR Creation Skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Before making changes, load the most relevant skill and follow it as the primary
 - `.github/skills/counterfact-runtime-architecture/SKILL.md`
 - `.github/skills/counterfact-generator-internals/SKILL.md`
 - `.github/skills/counterfact-maintenance/SKILL.md`
+- `.github/skills/counterfact-pr-creation/SKILL.md`
 - `.github/skills/counterfact-repo-basics/SKILL.md`
 
 Keep this file focused on cross-cutting rules that are not already covered by those skills.
@@ -17,47 +18,6 @@ Keep this file focused on cross-cutting rules that are not already covered by th
 ## Isolated change workspaces
 
 When implementing a new set of changes, create and use a dedicated branch in a separate Git worktree. Keep the original checkout available for integration work rather than making the changes there.
-
-## Manual acceptance tests
-
-Every PR description must include a section titled exactly `## Manual acceptance tests` with 3–6 unchecked checkboxes. Each checkbox must describe an observable behavior (not an implementation detail), and must not be pre-checked.
-
-- Cover the main success path, at least one edge case, and one regression check where applicable.
-- Exception: if a PR only adds files under `.github/issue-proposals/`, this section may be omitted.
-
-## Repository learning check
-
-For every non-trivial PR, include this section in the PR description:
-
-```markdown
-## Repository learning check
-
-- Learning found: Yes/No
-- Guidance updated: Yes/No
-- Updated file(s): N/A or list files
-- Rationale: one sentence explaining why the repository guidance did or did not need to change
-```
-
-If `Learning found: Yes`, update the most relevant repository guidance in the same PR.
-
-Use the following decision tree:
-
-- Runtime behavior, REPL behavior, request handling, context usage, server lifecycle, or application architecture → update the appropriate `SKILL.md`
-- Generator behavior, code generation patterns, route generation, OpenAPI processing, overlays, or specification handling → update the appropriate `SKILL.md`
-- Build, test, release, CI/CD, dependency management, repository maintenance, or contributor workflow → update the appropriate `SKILL.md`
-- Cross-cutting conventions that apply throughout the repository → update this file
-
-A durable learning is a reusable rule, pattern, validation step, compatibility concern, testing strategy, architectural constraint, or repository-specific convention that would help future contributors avoid mistakes or work more effectively.
-
-Do not create guidance for:
-
-- One-off implementation details
-- Temporary workarounds
-- Decisions that only apply to the current PR
-- Historical commentary
-- Task summaries
-
-If no durable learning was discovered, explicitly record `Learning found: No` and do not create or modify guidance files solely to satisfy this requirement.
 
 ## File system operations in tests
 


### PR DESCRIPTION
## Summary

Move agent-only PR authoring requirements into a dedicated skill, clarify that reviewers must not look for those sections, and prevent the shared template from opting every PR into acceptance-test validation.

<details>
<summary>Original Prompt</summary>

Update AGENTS.md to clarify that “Manual acceptance tests” and “Repository learning check are intended for the agent creating the PR. Their absence most likely means the PR was not opened by an agent. A reviewing agent should not look for them. This is getting a bit long-winded. If it’s not already split out, move PR guidance to a dedicated skill. After making this change on a branch, push and create a PR.

</details>

## Manual acceptance tests

- [x] An agent opening a PR can find the complete acceptance-test and learning-check requirements in `counterfact-pr-creation`.
- [x] A reviewer can see that absent agent-authored sections are not review deficiencies.
- [x] A human-authored PR using the shared template does not gain a `Manual acceptance tests` heading unless its author adds one.

## Repository learning check

- Learning found: Yes
- Guidance updated: Yes
- Updated file(s): AGENTS.md; .github/skills/counterfact-pr-creation/SKILL.md; .github/skills/counterfact-maintenance/SKILL.md; .github/pull_request_template.md
- Rationale: The agent-author versus reviewer boundary is a durable contributor-workflow convention that needed one dedicated, discoverable source of truth.

## Tasks

- Moved PR creation requirements from AGENTS.md into a dedicated skill.
- Clarified creator and reviewer responsibilities in the skill and template.
- Removed the template heading that unintentionally opted every PR into manual-acceptance validation.

## Validation

- `python3 /Users/pmcelhaney/.codex/skills/.system/skill-creator/scripts/quick_validate.py .github/skills/counterfact-pr-creation`
- `git diff --check`
- `mise exec node@24 -- corepack yarn lint` *(not run successfully: dependencies are not installed in this isolated worktree)*