### PR TITLE
Add Counterfact introduction to quality study

### DIFF
--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -54,6 +54,28 @@ const fullAfter = comparisonSummary[1];
     </header>
 
     <div class="article-body quality-reading quality-prose">
+      <section aria-labelledby="what-is-counterfact">
+        <h2 id="what-is-counterfact">What is Counterfact?</h2>
+        <p>
+          Counterfact is an open-source TypeScript tool that turns an OpenAPI
+          description into a live, stateful mock API. It gives frontend and
+          API-consuming teams a useful local service to build against, explore,
+          and test before the real backend is ready.
+        </p>
+        <p>
+          I, <a href="https://patrickmcelhaney.org/">Patrick McElhaney</a>, have
+          been working on Counterfact since 2022. Its source is available in the{" "}
+          <a href="https://github.com/counterfact/api-simulator">Counterfact GitHub repository</a>.
+        </p>
+        <p>
+          Adoption is difficult to count. I know of a handful of teams using
+          Counterfact. Public signals, including GitHub stars and npm downloads,
+          suggest its reach is more widespread, although neither measures active
+          teams: stars express interest, and downloads can include repeat or
+          automated installations.
+        </p>
+      </section>
+
       <section aria-labelledby="study-question">
         <h2 id="study-question">Research question</h2>
         <p>


### PR DESCRIPTION
## Summary

- Add a What is Counterfact? section to the 2026 quality-study main page.
- Explain the local OpenAPI-to-stateful-mock-API workflow and link the author and source repository.
- Frame known team use and public adoption signals without presenting stars or downloads as an active-team count.

## Validation

- npm --prefix site run build
- git diff --check

## Manual acceptance tests

- [x] Open /quality/2026 and confirm the new What is Counterfact? section explains that the tool creates a live, stateful local mock API from an OpenAPI description.
- [x] Select Patrick McElhaney and confirm it opens the personal website.
- [x] Select Counterfact GitHub repository and confirm it opens the project repository.
- [x] Continue to the Research question section and confirm the quality-study content remains available after the new introduction.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: This is a focused content addition that followed existing Astro and evidence-bound adoption-copy conventions.