### PR TITLE
Remove adoption paragraph from quality study

### DIFF
--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -67,13 +67,6 @@ const fullAfter = comparisonSummary[1];
           been working on Counterfact since 2022. Its source is available in the{" "}
           <a href="https://github.com/counterfact/api-simulator">Counterfact GitHub repository</a>.
         </p>
-        <p>
-          Adoption is difficult to count. I know of a handful of teams using
-          Counterfact. Public signals, including GitHub stars and npm downloads,
-          suggest its reach is more widespread, although neither measures active
-          teams: stars express interest, and downloads can include repeat or
-          automated installations.
-        </p>
       </section>
 
       <section aria-labelledby="study-question">


### PR DESCRIPTION
## Summary

- Remove the adoption paragraph from the quality-study main page.
- Keep the What is Counterfact? purpose, project history, author link, and GitHub repository link unchanged.

## Validation

- npm --prefix site run build
- git diff --check
- Confirmed the generated /quality/2026/ HTML no longer contains the removed adoption wording and still contains the introduction links.

## Manual acceptance tests

- [x] Open /quality/2026 and confirm the What is Counterfact? section remains visible.
- [x] Confirm the adoption paragraph about known teams, GitHub stars, and npm downloads is no longer displayed.
- [x] Select Patrick McElhaney and confirm the personal-site link still opens.
- [x] Select Counterfact GitHub repository and confirm the repository link still opens.
- [x] Continue through the Research question and Methods sections and confirm the quality-study content remains intact.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: This is a focused copy removal and does not reveal a durable repository workflow or technical lesson requiring guidance changes.