### PR TITLE
Link Counterfact in quality-study lede

### DIFF
--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -31,11 +31,12 @@ const fullAfter = comparisonSummary[1];
       <h1>Did AI-assisted development change Counterfact’s software quality?</h1>
       <p class="article-byline">Patrick McElhaney via Codex · September 4, 2026</p>
       <p class="article-lede">
-        Counterfact is a TypeScript tool that turns an OpenAPI description into a
-        live, stateful mock API. On March 10, 2026, I began merging work authored
-        by coding agents into the project. I wanted to answer a simple question:
-        has quality increased, decreased, or stayed the same since I started
-        using AI?
+        <a href="https://github.com/counterfact/api-simulator">Counterfact</a> is
+        a TypeScript tool that turns an OpenAPI description into a live, stateful
+        mock API. On March 10, 2026, I began merging work authored by coding
+        agents into the project. I wanted to answer a simple question: has
+        quality increased, decreased, or stayed the same since I started using
+        AI?
       </p>
       <section class="abstract" aria-labelledby="abstract-heading">
         <h2 id="abstract-heading">Abstract</h2>
@@ -54,21 +55,6 @@ const fullAfter = comparisonSummary[1];
     </header>
 
     <div class="article-body quality-reading quality-prose">
-      <section aria-labelledby="what-is-counterfact">
-        <h2 id="what-is-counterfact">What is Counterfact?</h2>
-        <p>
-          Counterfact is an open-source TypeScript tool that turns an OpenAPI
-          description into a live, stateful mock API. It gives frontend and
-          API-consuming teams a useful local service to build against, explore,
-          and test before the real backend is ready.
-        </p>
-        <p>
-          I, <a href="https://patrickmcelhaney.org/">Patrick McElhaney</a>, have
-          been working on Counterfact since 2022. Its source is available in the{" "}
-          <a href="https://github.com/counterfact/api-simulator">Counterfact GitHub repository</a>.
-        </p>
-      </section>
-
       <section aria-labelledby="study-question">
         <h2 id="study-question">Research question</h2>
         <p>


### PR DESCRIPTION
## Summary

- Remove the standalone What is Counterfact? section from the quality-study main page.
- Link the word Counterfact in the lede immediately before the abstract to the project repository.
- Preserve the surrounding quality-study content and structure.

## Validation

- npm --prefix site run build
- git diff --check
- Confirmed generated /quality/2026/ HTML contains the repository link on the lede and no standalone What is Counterfact? section or adoption paragraph.

## Manual acceptance tests

- [x] Open /quality/2026 and confirm the lede appears directly before the Abstract section.
- [x] Select the linked word Counterfact in the lede and confirm it opens the project GitHub repository.
- [x] Confirm no standalone What is Counterfact? section appears below the abstract.
- [x] Continue through the Research question and Methods sections and confirm the quality-study content remains intact.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: This is a focused copy and link-placement adjustment and does not reveal a durable repository workflow or technical lesson requiring guidance changes.