### PR TITLE
Add historical cohorts and retrospective quality benchmarks

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "snapshot:audit": "node scripts/quality-snapshot.mjs",
+    "snapshot:churn": "node scripts/quality-churn.mjs",
     "test:audit": "node --test scripts/quality-audit.test.mjs",
     "verify:audit": "node scripts/verify-quality-audit.mjs",
     "preview": "astro preview",

--- a/site/scripts/quality-audit-lib.mjs
+++ b/site/scripts/quality-audit-lib.mjs
@@ -56,6 +56,14 @@ export function matureCases(cases, windowEndExclusive, maturityDays) {
 }
 
 export function validateManifest(manifest) {
+  try {
+    return validateManifestUnchecked(manifest);
+  } catch (error) {
+    return [`manifest validation could not complete: ${error.message}`];
+  }
+}
+
+function validateManifestUnchecked(manifest) {
   const errors = [];
   if (manifest.schemaVersion !== 2)
     errors.push(`unsupported schema version: ${manifest.schemaVersion}`);

--- a/site/scripts/quality-audit-lib.mjs
+++ b/site/scripts/quality-audit-lib.mjs
@@ -148,5 +148,40 @@ export function validateManifest(manifest) {
       );
     }
   }
+
+  const gitCohorts = manifest.activity.cohortGitMetrics?.cohorts;
+  if (
+    manifest.activity.cohortGitMetrics?.analysisRef !==
+    manifest.generatedForCommit
+  ) {
+    errors.push("cohort Git analysis ref does not match generated-for commit");
+  }
+  if (!gitCohorts) {
+    errors.push("missing cohort Git metrics");
+  } else {
+    for (const year of [2022, 2023, 2024, 2025, 2026]) {
+      const cohort = gitCohorts[String(year)];
+      if (!cohort) {
+        errors.push(`missing ${year} cohort Git metrics`);
+        continue;
+      }
+      if (cohort.additions + cohort.deletions !== cohort.churn) {
+        errors.push(`${year} additions and deletions do not equal churn`);
+      }
+      const categorizedChurn = Object.values(cohort.categoryChurn).reduce(
+        (total, value) => total + value,
+        0,
+      );
+      if (categorizedChurn !== cohort.churn) {
+        errors.push(
+          `${year} categorized churn ${categorizedChurn} does not equal ${cohort.churn}`,
+        );
+      }
+    }
+  }
+
+  if (!manifest.study?.retrospectiveComparison?.constructedAfterObservation) {
+    errors.push("retrospective comparison disclosure is missing");
+  }
   return errors;
 }

--- a/site/scripts/quality-audit.test.mjs
+++ b/site/scripts/quality-audit.test.mjs
@@ -467,3 +467,17 @@ test("validateManifest catches incomplete evidence relationships", () => {
   };
   assert.ok(validateManifest(manifest).length >= 8);
 });
+
+test("validateManifest reports structurally incomplete manifests", () => {
+  const errors = validateManifest({
+    schemaVersion: 2,
+    productCases: [],
+    candidates: [],
+    processIncidents: [],
+  });
+  assert.ok(
+    errors.some((error) =>
+      error.startsWith("manifest validation could not complete:"),
+    ),
+  );
+});

--- a/site/scripts/quality-audit.test.mjs
+++ b/site/scripts/quality-audit.test.mjs
@@ -10,6 +10,11 @@ import {
   summarizeCases,
   validateManifest,
 } from "./quality-audit-lib.mjs";
+import {
+  classifyPath,
+  isCommitInCohortWindow,
+  parseNumstat,
+} from "./quality-churn-lib.mjs";
 
 test("summarizeCases keeps report years and categories separate", () => {
   const cases = [
@@ -44,6 +49,49 @@ test("primary windows include the start and exclude the end", () => {
   assert.equal(isWithinWindow("2026-03-10T16:38:20Z", window), true);
   assert.equal(isWithinWindow("2026-09-03T23:59:59Z", window), true);
   assert.equal(isWithinWindow("2026-09-04T00:00:00Z", window), false);
+});
+
+test("churn windows include the exact start and exclude the exact end", () => {
+  assert.equal(
+    isCommitInCohortWindow(2026, "2026-03-10T11:38:20-05:00"),
+    true,
+  );
+  assert.equal(
+    isCommitInCohortWindow(2026, "2026-09-04T00:00:00Z"),
+    false,
+  );
+});
+
+test("churn path categories apply a stable, exclusive priority", () => {
+  assert.equal(classifyPath(".yarn/releases/yarn.cjs"), "lockOrGenerated");
+  assert.equal(classifyPath("site/src/pages/example.test.ts"), "tests");
+  assert.equal(classifyPath("site/src/pages/index.astro"), "documentation");
+  assert.equal(classifyPath("packages/runtime/src/index.ts"), "sourceOrOther");
+});
+
+test("numstat parser handles ordinary, renamed, and binary records", () => {
+  const records = parseNumstat(
+    Buffer.from(
+      "2\t1\tpackages/runtime/src/index.ts\0" +
+        "0\t0\t\0old.test.ts\0new.test.ts\0" +
+        "-\t-\timage.png\0",
+    ),
+  );
+  assert.deepEqual(records, [
+    {
+      added: "2",
+      deleted: "1",
+      path: "packages/runtime/src/index.ts",
+      renamed: false,
+    },
+    {
+      added: "0",
+      deleted: "0",
+      path: "new.test.ts",
+      renamed: true,
+    },
+    { added: "-", deleted: "-", path: "image.png", renamed: false },
+  ]);
 });
 
 test("reported and introduced cohorts remain distinct", () => {
@@ -92,6 +140,269 @@ test("checked-in primary cohorts reproduce the article results", () => {
     { year: 2025, reports: 3, introduced: 0, medianResponseDays: 6 },
     { year: 2026, reports: 7, introduced: 0, medianResponseDays: 1 },
   ]);
+});
+
+test("automated verification snapshots report the historical cohort additions", () => {
+  const { comparison2022, comparison2023, comparison2024, comparison2025 } =
+    manifest.activity.snapshots;
+  const { preAdoption, endOfObservation } = manifest.activity.snapshots;
+  assert.deepEqual(
+    {
+      comparison2022: {
+        status: comparison2022.status,
+        endTestFiles: comparison2022.end.testFiles,
+        endTestDeclarations: comparison2022.end.testDeclarations,
+      },
+      comparison2023: {
+        testFiles: comparison2023.end.testFiles - comparison2023.start.testFiles,
+        testDeclarations:
+          comparison2023.end.testDeclarations - comparison2023.start.testDeclarations,
+      },
+      comparison2024: {
+        testFiles: comparison2024.end.testFiles - comparison2024.start.testFiles,
+        testDeclarations:
+          comparison2024.end.testDeclarations - comparison2024.start.testDeclarations,
+      },
+      comparison2025: {
+        testFiles: comparison2025.end.testFiles - comparison2025.start.testFiles,
+        testDeclarations:
+          comparison2025.end.testDeclarations -
+          comparison2025.start.testDeclarations,
+      },
+      aiCohort: {
+        testFiles: endOfObservation.testFiles - preAdoption.testFiles,
+        testDeclarations:
+          endOfObservation.testDeclarations - preAdoption.testDeclarations,
+        lineCoveragePercentagePoints: Number(
+          (
+            endOfObservation.lineCoveragePercent -
+            preAdoption.lineCoveragePercent
+          ).toFixed(3),
+        ),
+      },
+    },
+    {
+      comparison2022: {
+        status: "not_estimable",
+        endTestFiles: 21,
+        endTestDeclarations: 94,
+      },
+      comparison2023: { testFiles: 0, testDeclarations: 10 },
+      comparison2024: { testFiles: 6, testDeclarations: 48 },
+      comparison2025: { testFiles: 1, testDeclarations: 6 },
+      aiCohort: {
+        testFiles: 36,
+        testDeclarations: 634,
+        lineCoveragePercentagePoints: 8.846,
+      },
+    },
+  );
+});
+
+test("historic delivery and coverage retain matched-window limitations", () => {
+  const cohorts = manifest.activity.historicCohorts;
+  assert.deepEqual(
+    {
+      2022: {
+        nonDependencyMerges: cohorts["2022"].nonDependencyMergedPullRequests,
+        releases: cohorts["2022"].publishedReleases,
+        coverageStatus: cohorts["2022"].coverage.status,
+      },
+      2023: {
+        nonDependencyMerges: cohorts["2023"].nonDependencyMergedPullRequests,
+        releases: cohorts["2023"].publishedReleases,
+        coverageChange: Number(
+          (
+            cohorts["2023"].coverage.end.coveredPercent -
+            cohorts["2023"].coverage.start.coveredPercent
+          ).toFixed(3),
+        ),
+      },
+      2024: {
+        nonDependencyMerges: cohorts["2024"].nonDependencyMergedPullRequests,
+        releases: cohorts["2024"].publishedReleases,
+        coverageChange: Number(
+          (
+            cohorts["2024"].coverage.end.coveredPercent -
+            cohorts["2024"].coverage.start.coveredPercent
+          ).toFixed(3),
+        ),
+      },
+    },
+    {
+      2022: {
+        nonDependencyMerges: 63,
+        releases: 7,
+        coverageStatus: "not_estimable",
+      },
+      2023: {
+        nonDependencyMerges: 50,
+        releases: 19,
+        coverageChange: -2.294,
+      },
+      2024: {
+        nonDependencyMerges: 75,
+        releases: 24,
+        coverageChange: -3.629,
+      },
+    },
+  );
+});
+
+test("historic defect cohorts distinguish reports from introduced defects", () => {
+  const cohorts = manifest.activity.historicDefectCohorts;
+  assert.deepEqual(
+    {
+      2022: {
+        reports: cohorts["2022"].qualifyingExternalProductDefects,
+        introduced: cohorts["2022"].introducedWithinWindow,
+        median: cohorts["2022"].medianResponseDays,
+      },
+      2023: {
+        reports: cohorts["2023"].qualifyingExternalProductDefects,
+        introduced: cohorts["2023"].introducedWithinWindow,
+        median: cohorts["2023"].medianResponseDays,
+        introducedReports: cohorts["2023"].introducedReports.map(
+          (report) => report.number,
+        ),
+      },
+      2024: {
+        reports: cohorts["2024"].qualifyingExternalProductDefects,
+        introduced: cohorts["2024"].introducedWithinWindow,
+        median: cohorts["2024"].medianResponseDays,
+        introducedReports: cohorts["2024"].introducedReports.map(
+          (report) => report.number,
+        ),
+      },
+    },
+    {
+      2022: { reports: 0, introduced: 0, median: null },
+      2023: { reports: 5, introduced: 1, median: 5, introducedReports: [491] },
+      2024: {
+        reports: 7,
+        introduced: 3,
+        median: 6,
+        introducedReports: [866, 906, 918],
+      },
+    },
+  );
+});
+
+test("checked-in commit and churn metrics retain exact matched-window totals", () => {
+  const cohorts = manifest.activity.cohortGitMetrics.cohorts;
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(cohorts).map(([year, cohort]) => [year, {
+        firstParentCommits: cohort.firstParentCommits,
+        additions: cohort.additions,
+        deletions: cohort.deletions,
+        churn: cohort.churn,
+        categoryChurn: Object.values(cohort.categoryChurn).reduce(
+          (total, value) => total + value,
+          0,
+        ),
+      }]),
+    ),
+    {
+      2022: { firstParentCommits: 181, additions: 42770, deletions: 9252, churn: 52022, categoryChurn: 52022 },
+      2023: { firstParentCommits: 129, additions: 7535, deletions: 5036, churn: 12571, categoryChurn: 12571 },
+      2024: { firstParentCommits: 205, additions: 163929, deletions: 165287, churn: 329216, categoryChurn: 329216 },
+      2025: { firstParentCommits: 152, additions: 9714, deletions: 7256, churn: 16970, categoryChurn: 16970 },
+      2026: { firstParentCommits: 548, additions: 104938, deletions: 46409, churn: 151347, categoryChurn: 151347 },
+    },
+  );
+  assert.equal(cohorts["2022"].status, "partial_history");
+  assert.equal(cohorts["2024"].categoryChurn.lockOrGenerated, 312983);
+});
+
+test("retrospective baselines use every complete eligible pre-AI cohort", () => {
+  const delivery = manifest.activity.historicCohorts;
+  const defects = manifest.activity.historicDefectCohorts;
+  const primary = manifest.activity.primaryWindow;
+  const historicNonDependencyMerges = [
+    delivery["2022"].nonDependencyMergedPullRequests,
+    delivery["2023"].nonDependencyMergedPullRequests,
+    delivery["2024"].nonDependencyMergedPullRequests,
+    primary.nonDependencyMergedPullRequests["2025"],
+  ];
+  const historicReleases = [
+    delivery["2022"].publishedReleases,
+    delivery["2023"].publishedReleases,
+    delivery["2024"].publishedReleases,
+    primary.publishedReleases["2025"],
+  ];
+  const historicIntroductions =
+    defects["2022"].introducedWithinWindow +
+    defects["2023"].introducedWithinWindow +
+    defects["2024"].introducedWithinWindow +
+    selectIntroducedCases(
+      manifest.productCases,
+      2025,
+      manifest.study.primaryWindows["2025"],
+    ).length;
+  const pooledMerges = historicNonDependencyMerges.reduce(
+    (total, value) => total + value,
+    0,
+  );
+  assert.equal(median(historicNonDependencyMerges), 56.5);
+  assert.equal(median(historicReleases), 13);
+  assert.equal(
+    median([
+      0,
+      6,
+      1,
+    ]),
+    1,
+  );
+  assert.equal(median([10, 48, 6]), 10);
+  assert.equal(
+    median([
+      defects["2022"].qualifyingExternalProductDefects,
+      defects["2023"].qualifyingExternalProductDefects,
+      defects["2024"].qualifyingExternalProductDefects,
+      3,
+    ]),
+    4,
+  );
+  assert.equal(median([5, 6, 6]), 6);
+  assert.deepEqual(
+    {
+      gitCommitMedian: median([129, 205, 152]),
+      gitChurnMedian: median([12571, 329216, 16970]),
+    },
+    { gitCommitMedian: 152, gitChurnMedian: 16970 },
+  );
+  assert.equal(pooledMerges, 203);
+  assert.equal(historicIntroductions, 4);
+  assert.equal(
+    Number(
+      (
+        (historicIntroductions / pooledMerges) *
+        primary.nonDependencyMergedPullRequests["2026"]
+      ).toFixed(2),
+    ),
+    5.54,
+  );
+});
+
+test("coverage reference stays a two-cohort descriptive midpoint", () => {
+  const cohorts = manifest.activity.historicCohorts;
+  const changes = ["2023", "2024"].map(
+    (year) =>
+      cohorts[year].coverage.end.coveredPercent -
+      cohorts[year].coverage.start.coveredPercent,
+  );
+  assert.equal(Number(median(changes).toFixed(3)), -2.961);
+  assert.equal(
+    Number(
+      (
+        manifest.activity.snapshots.endOfObservation.lineCoveragePercent -
+        manifest.activity.snapshots.preAdoption.lineCoveragePercent -
+        median(changes)
+      ).toFixed(3),
+    ),
+    11.807,
+  );
 });
 
 test("candidate ledger exposes every reviewed disposition", () => {

--- a/site/scripts/quality-churn-lib.mjs
+++ b/site/scripts/quality-churn-lib.mjs
@@ -1,0 +1,38 @@
+const lockOrGeneratedPath =
+  /(^|\/)\.yarn\/|(^|\/)(yarn\.lock|package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|bun\.lockb?|cargo\.lock)$|(^|\/)(dist|coverage|\.astro)(\/|$)|\.tsbuildinfo$/i;
+const testPath =
+  /(^|\/)(test|tests|__tests__|test-black-box)(\/|$)|\.(test|spec)\.[^/]+$/i;
+const documentationPath =
+  /(^|\/)(docs|documentation|site|\.changeset)(\/|$)|(^|\/)(readme|changelog|contributing|license|security|code_of_conduct)(\.[^/]*)?$|\.(md|mdx|rst|adoc)$/i;
+
+export const classifyPath = (path) => {
+  if (lockOrGeneratedPath.test(path)) return "lockOrGenerated";
+  if (testPath.test(path)) return "tests";
+  if (documentationPath.test(path)) return "documentation";
+  return "sourceOrOther";
+};
+
+export const parseNumstat = (buffer) => {
+  const fields = buffer.toString("utf8").split("\0");
+  const records = [];
+  for (let index = 0; index < fields.length - 1; index += 1) {
+    const field = fields[index];
+    const [added, deleted, path = ""] = field.split("\t");
+    if (added === undefined || deleted === undefined) continue;
+    if (path === "") {
+      index += 2;
+      records.push({ added, deleted, path: fields[index], renamed: true });
+    } else {
+      records.push({ added, deleted, path, renamed: false });
+    }
+  }
+  return records;
+};
+
+export const isCommitInCohortWindow = (year, committedAt) => {
+  const value = Date.parse(committedAt);
+  return (
+    value >= Date.parse(`${year}-03-10T16:38:20Z`) &&
+    value < Date.parse(`${year}-09-04T00:00:00Z`)
+  );
+};

--- a/site/scripts/quality-churn.mjs
+++ b/site/scripts/quality-churn.mjs
@@ -1,0 +1,116 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  classifyPath,
+  isCommitInCohortWindow,
+  parseNumstat,
+} from "./quality-churn-lib.mjs";
+
+const run = promisify(execFile);
+const ref =
+  process.argv[2] ?? "77f0bc6fd2c3bc935d2eb2da80190369d91f7084";
+const years = [2022, 2023, 2024, 2025, 2026];
+
+const { stdout: repoRoot } = await run("git", [
+  "rev-parse",
+  "--show-toplevel",
+]);
+const gitOptions = {
+  cwd: repoRoot.trim(),
+  maxBuffer: 100 * 1024 * 1024,
+  encoding: "buffer",
+};
+
+const gitText = async (args) => {
+  const { stdout } = await run("git", args, gitOptions);
+  return stdout.toString("utf8");
+};
+
+const datedCommits = async () => {
+  const args = ["log", ref, "--first-parent", "--format=%H%x09%cI"];
+  const output = await gitText(args);
+  return output
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [commit, committedAt] = line.split("\t");
+      return { commit, committedAt };
+    });
+};
+
+const diffFor = async (commit) => {
+  const parents = (await gitText(["rev-list", "--parents", "-n", "1", commit]))
+    .trim()
+    .split(" ")
+    .slice(1);
+  const args =
+    parents.length === 0
+      ? ["diff-tree", "--root", "--numstat", "-M", "-z", "--no-commit-id", "-r", commit]
+      : ["diff", "--numstat", "-M", "-z", parents[0], commit];
+  const { stdout } = await run("git", args, gitOptions);
+  return parseNumstat(stdout);
+};
+
+const firstParentHistory = await datedCommits();
+const results = {};
+
+for (const year of years) {
+  const commits = firstParentHistory.filter((item) =>
+    isCommitInCohortWindow(year, item.committedAt),
+  );
+  const totals = {
+    additions: 0,
+    deletions: 0,
+    churn: 0,
+    fileTouchOccurrences: 0,
+    binaryFileTouchOccurrences: 0,
+    renamedFileOccurrences: 0,
+  };
+  const categories = Object.fromEntries(
+    ["tests", "documentation", "lockOrGenerated", "sourceOrOther"].map(
+      (category) => [category, {
+        additions: 0,
+        deletions: 0,
+        churn: 0,
+        fileTouchOccurrences: 0,
+        binaryFileTouchOccurrences: 0,
+      }],
+    ),
+  );
+
+  for (const { commit } of commits) {
+    for (const record of await diffFor(commit)) {
+      const category = categories[classifyPath(record.path)];
+      totals.fileTouchOccurrences += 1;
+      category.fileTouchOccurrences += 1;
+      if (record.renamed) totals.renamedFileOccurrences += 1;
+      if (record.added === "-" || record.deleted === "-") {
+        totals.binaryFileTouchOccurrences += 1;
+        category.binaryFileTouchOccurrences += 1;
+        continue;
+      }
+      const additions = Number(record.added);
+      const deletions = Number(record.deleted);
+      totals.additions += additions;
+      totals.deletions += deletions;
+      category.additions += additions;
+      category.deletions += deletions;
+    }
+  }
+
+  totals.churn = totals.additions + totals.deletions;
+  for (const category of Object.values(categories)) {
+    category.churn = category.additions + category.deletions;
+  }
+
+  results[String(year)] = {
+    start: `${year}-03-10T16:38:20Z`,
+    endExclusive: `${year}-09-04T00:00:00Z`,
+    firstParentCommits: commits.length,
+    ...totals,
+    categories,
+  };
+}
+
+console.log(JSON.stringify({ ref, clock: "committer timestamp", cohorts: results }, null, 2));

--- a/site/scripts/verify-quality-audit.mjs
+++ b/site/scripts/verify-quality-audit.mjs
@@ -63,6 +63,34 @@ console.log(
     .join(", ")}).`,
 );
 
+const historicalCohorts = manifest.activity.historicCohorts;
+const historicalDefects = manifest.activity.historicDefectCohorts;
+const pooledHistoricalMerges =
+  historicalCohorts["2022"].nonDependencyMergedPullRequests +
+  historicalCohorts["2023"].nonDependencyMergedPullRequests +
+  historicalCohorts["2024"].nonDependencyMergedPullRequests +
+  manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2025"];
+const pooledHistoricalIntroductions =
+  historicalDefects["2022"].introducedWithinWindow +
+  historicalDefects["2023"].introducedWithinWindow +
+  historicalDefects["2024"].introducedWithinWindow +
+  selectIntroducedCases(
+    manifest.productCases,
+    2025,
+    manifest.study.primaryWindows["2025"],
+  ).length;
+const exposureScaledBenchmark =
+  (pooledHistoricalIntroductions / pooledHistoricalMerges) *
+  manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2026"];
+console.log(
+  `Retrospective defect benchmark: ${pooledHistoricalIntroductions}/${pooledHistoricalMerges} pre-AI introductions per non-dependency PR; ${exposureScaledBenchmark.toFixed(2)} after scaling to the 2026 exposure.`,
+);
+
+const gitCohorts = manifest.activity.cohortGitMetrics.cohorts;
+console.log(
+  `2026 Git activity: ${gitCohorts["2026"].firstParentCommits} first-parent commits; ${gitCohorts["2026"].additions.toLocaleString()} additions; ${gitCohorts["2026"].deletions.toLocaleString()} deletions; ${gitCohorts["2026"].churn.toLocaleString()} lines of churn.`,
+);
+
 if (errors.length > 0) {
   for (const error of errors) console.error(`ERROR: ${error}`);
   process.exitCode = 1;

--- a/site/scripts/verify-quality-audit.mjs
+++ b/site/scripts/verify-quality-audit.mjs
@@ -15,85 +15,88 @@ const manifestPath = fileURLToPath(
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 const errors = validateManifest(manifest);
 
-for (const year of [2025, 2026]) {
-  const primaryWindow = manifest.study.primaryWindows[String(year)];
-  const primaryCases = selectReportedCases(
-    manifest.productCases,
-    year,
-    primaryWindow,
+function printDiagnostics(manifest) {
+  for (const year of [2025, 2026]) {
+    const primaryWindow = manifest.study.primaryWindows[String(year)];
+    const primaryCases = selectReportedCases(
+      manifest.productCases,
+      year,
+      primaryWindow,
+    );
+    const introduced = selectIntroducedCases(
+      manifest.productCases,
+      year,
+      primaryWindow,
+    );
+    const responseMedian = median(primaryCases.map((item) => item.responseDays));
+    const nonDependencyMerges =
+      manifest.activity.primaryWindow.nonDependencyMergedPullRequests[String(year)];
+    console.log(
+      `${year} primary window: ${primaryCases.length} external product reports; ${introduced.length} first affected releases entered during the window (${introduced.length === 0 ? "0" : ((introduced.length / nonDependencyMerges) * 100).toFixed(2)} per 100 non-dependency merges); median report-to-release time: ${responseMedian} ${responseMedian === 1 ? "day" : "days"}.`,
+    );
+
+    const cases = manifest.productCases.filter(
+      (item) => item.reportYear === year,
+    );
+    const summary = summarizeCases(cases, year);
+    const matureSummary = summarizeCases(
+      matureCases(
+        cases,
+        manifest.study.supplementalWindows[String(year)].endExclusive,
+        manifest.maturityDays,
+      ),
+      year,
+    );
+    console.log(
+      `${year}: ${summary.total} product defects (${summary.counts["Same-year regression"]} regressions, ${summary.counts["Defect in same-year feature"]} feature defects, ${summary.counts["Pre-existing"]} pre-existing); 90-day sensitivity: ${matureSummary.total}`,
+    );
+  }
+
+  const dispositionCounts = Object.groupBy(
+    manifest.candidates,
+    (item) => item.disposition,
   );
-  const introduced = selectIntroducedCases(
-    manifest.productCases,
-    year,
-    primaryWindow,
-  );
-  const responseMedian = median(primaryCases.map((item) => item.responseDays));
-  const nonDependencyMerges =
-    manifest.activity.primaryWindow.nonDependencyMergedPullRequests[String(year)];
   console.log(
-    `${year} primary window: ${primaryCases.length} external product reports; ${introduced.length} first affected releases entered during the window (${introduced.length === 0 ? "0" : ((introduced.length / nonDependencyMerges) * 100).toFixed(2)} per 100 non-dependency merges); median report-to-release time: ${responseMedian} ${responseMedian === 1 ? "day" : "days"}.`,
+    `Candidate ledger: ${manifest.candidates.length} records (${Object.entries(
+      dispositionCounts,
+    )
+      .map(([disposition, items]) => `${items.length} ${disposition}`)
+      .join(", ")}).`,
   );
 
-  const cases = manifest.productCases.filter(
-    (item) => item.reportYear === year,
-  );
-  const summary = summarizeCases(cases, year);
-  const matureSummary = summarizeCases(
-    matureCases(
-      cases,
-        manifest.study.supplementalWindows[String(year)].endExclusive,
-      manifest.maturityDays,
-    ),
-    year,
-  );
+  const historicalCohorts = manifest.activity.historicCohorts;
+  const historicalDefects = manifest.activity.historicDefectCohorts;
+  const pooledHistoricalMerges =
+    historicalCohorts["2022"].nonDependencyMergedPullRequests +
+    historicalCohorts["2023"].nonDependencyMergedPullRequests +
+    historicalCohorts["2024"].nonDependencyMergedPullRequests +
+    manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2025"];
+  const pooledHistoricalIntroductions =
+    historicalDefects["2022"].introducedWithinWindow +
+    historicalDefects["2023"].introducedWithinWindow +
+    historicalDefects["2024"].introducedWithinWindow +
+    selectIntroducedCases(
+      manifest.productCases,
+      2025,
+      manifest.study.primaryWindows["2025"],
+    ).length;
+  const exposureScaledBenchmark =
+    (pooledHistoricalIntroductions / pooledHistoricalMerges) *
+    manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2026"];
   console.log(
-    `${year}: ${summary.total} product defects (${summary.counts["Same-year regression"]} regressions, ${summary.counts["Defect in same-year feature"]} feature defects, ${summary.counts["Pre-existing"]} pre-existing); 90-day sensitivity: ${matureSummary.total}`,
+    `Retrospective defect benchmark: ${pooledHistoricalIntroductions}/${pooledHistoricalMerges} pre-AI introductions per non-dependency PR; ${exposureScaledBenchmark.toFixed(2)} after scaling to the 2026 exposure.`,
+  );
+
+  const gitCohorts = manifest.activity.cohortGitMetrics.cohorts;
+  console.log(
+    `2026 Git activity: ${gitCohorts["2026"].firstParentCommits} first-parent commits; ${gitCohorts["2026"].additions.toLocaleString()} additions; ${gitCohorts["2026"].deletions.toLocaleString()} deletions; ${gitCohorts["2026"].churn.toLocaleString()} lines of churn.`,
   );
 }
-
-const dispositionCounts = Object.groupBy(
-  manifest.candidates,
-  (item) => item.disposition,
-);
-console.log(
-  `Candidate ledger: ${manifest.candidates.length} records (${Object.entries(
-    dispositionCounts,
-  )
-    .map(([disposition, items]) => `${items.length} ${disposition}`)
-    .join(", ")}).`,
-);
-
-const historicalCohorts = manifest.activity.historicCohorts;
-const historicalDefects = manifest.activity.historicDefectCohorts;
-const pooledHistoricalMerges =
-  historicalCohorts["2022"].nonDependencyMergedPullRequests +
-  historicalCohorts["2023"].nonDependencyMergedPullRequests +
-  historicalCohorts["2024"].nonDependencyMergedPullRequests +
-  manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2025"];
-const pooledHistoricalIntroductions =
-  historicalDefects["2022"].introducedWithinWindow +
-  historicalDefects["2023"].introducedWithinWindow +
-  historicalDefects["2024"].introducedWithinWindow +
-  selectIntroducedCases(
-    manifest.productCases,
-    2025,
-    manifest.study.primaryWindows["2025"],
-  ).length;
-const exposureScaledBenchmark =
-  (pooledHistoricalIntroductions / pooledHistoricalMerges) *
-  manifest.activity.primaryWindow.nonDependencyMergedPullRequests["2026"];
-console.log(
-  `Retrospective defect benchmark: ${pooledHistoricalIntroductions}/${pooledHistoricalMerges} pre-AI introductions per non-dependency PR; ${exposureScaledBenchmark.toFixed(2)} after scaling to the 2026 exposure.`,
-);
-
-const gitCohorts = manifest.activity.cohortGitMetrics.cohorts;
-console.log(
-  `2026 Git activity: ${gitCohorts["2026"].firstParentCommits} first-parent commits; ${gitCohorts["2026"].additions.toLocaleString()} additions; ${gitCohorts["2026"].deletions.toLocaleString()} deletions; ${gitCohorts["2026"].churn.toLocaleString()} lines of churn.`,
-);
 
 if (errors.length > 0) {
   for (const error of errors) console.error(`ERROR: ${error}`);
   process.exitCode = 1;
 } else {
+  printDiagnostics(manifest);
   console.log("Audit evidence manifest is internally consistent.");
 }

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -366,6 +366,7 @@ const numberRange = (values: number[]) => ({
 });
 const displayNumber = (value: number, maximumFractionDigits = 2) =>
   value.toLocaleString("en-US", { maximumFractionDigits });
+const displayDays = (value: number) => `${value} ${value === 1 ? "day" : "days"}`;
 const displayRange = (values: number[], suffix = "") => {
   const range = numberRange(values);
   return `${displayNumber(range.minimum)}–${displayNumber(range.maximum)}${suffix}`;
@@ -500,7 +501,7 @@ export const retrospectiveBaselineRows = [
       actual2026.medianResponseDays,
       " days",
     ),
-    displayActual: `${actual2026.medianResponseDays} day`,
+    displayActual: displayDays(actual2026.medianResponseDays),
   },
   {
     label: "Introduced qualifying reports, exposure-scaled",

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -212,6 +212,38 @@ export const comparisonSummary = [
 }));
 
 const snapshots = evidence.activity.snapshots;
+const displaySignedChange = (value: number, unit = "") =>
+  `${value >= 0 ? "+" : ""}${value}${unit}`;
+type TestCountSnapshot = {
+  testFiles: number;
+  testDeclarations: number;
+};
+const cohortAddition = (
+  label: string,
+  start: TestCountSnapshot,
+  end: TestCountSnapshot,
+) => {
+  const testFilesAdded = end.testFiles - start.testFiles;
+  const declarationsAdded = end.testDeclarations - start.testDeclarations;
+  return {
+    label,
+    testFilesStart: start.testFiles,
+    testFilesEnd: end.testFiles,
+    testFilesAdded,
+    declarationsStart: start.testDeclarations,
+    declarationsEnd: end.testDeclarations,
+    declarationsAdded,
+    displayTestFiles: `${start.testFiles} → ${end.testFiles}`,
+    displayTestFilesAdded: displaySignedChange(testFilesAdded),
+    displayDeclarations: `${start.testDeclarations} → ${end.testDeclarations}`,
+    displayDeclarationsAdded: displaySignedChange(declarationsAdded),
+  };
+};
+const comparison2022Snapshots = snapshots.comparison2022;
+const comparison2023Snapshots = snapshots.comparison2023;
+const comparison2024Snapshots = snapshots.comparison2024;
+const comparison2025Snapshots = snapshots.comparison2025;
+
 export const testingMetrics = [
   {
     label: "Conventional test files",
@@ -219,6 +251,9 @@ export const testingMetrics = [
     after: snapshots.endOfObservation.testFiles,
     displayBefore: String(snapshots.preAdoption.testFiles),
     displayAfter: String(snapshots.endOfObservation.testFiles),
+    displayChange: displaySignedChange(
+      snapshots.endOfObservation.testFiles - snapshots.preAdoption.testFiles,
+    ),
   },
   {
     label: "Explicit test declarations",
@@ -226,6 +261,10 @@ export const testingMetrics = [
     after: snapshots.endOfObservation.testDeclarations,
     displayBefore: String(snapshots.preAdoption.testDeclarations),
     displayAfter: String(snapshots.endOfObservation.testDeclarations),
+    displayChange: displaySignedChange(
+      snapshots.endOfObservation.testDeclarations -
+        snapshots.preAdoption.testDeclarations,
+    ),
   },
   {
     label: "Reported line coverage",
@@ -233,8 +272,328 @@ export const testingMetrics = [
     after: snapshots.endOfObservation.lineCoveragePercent,
     displayBefore: `${snapshots.preAdoption.lineCoveragePercent}%`,
     displayAfter: `${snapshots.endOfObservation.lineCoveragePercent}%`,
+    displayChange: displaySignedChange(
+      Number(
+        (
+          snapshots.endOfObservation.lineCoveragePercent -
+          snapshots.preAdoption.lineCoveragePercent
+        ).toFixed(3),
+      ),
+      " percentage points",
+    ),
   },
 ] as const;
+
+export const testCohortAdditions = [
+  {
+    label: "2022 comparison",
+    note: comparison2022Snapshots.reason,
+    displayTestFiles: `Not available → ${comparison2022Snapshots.end.testFiles}`,
+    displayTestFilesAdded: "Not estimable",
+    displayDeclarations: `Not available → ${comparison2022Snapshots.end.testDeclarations}`,
+    displayDeclarationsAdded: "Not estimable",
+  },
+  cohortAddition(
+    "2023 comparison",
+    comparison2023Snapshots.start,
+    comparison2023Snapshots.end,
+  ),
+  cohortAddition(
+    "2024 comparison",
+    comparison2024Snapshots.start,
+    comparison2024Snapshots.end,
+  ),
+  cohortAddition(
+    "2025 comparison",
+    comparison2025Snapshots.start,
+    comparison2025Snapshots.end,
+  ),
+  cohortAddition(
+    "2026 AI cohort",
+    snapshots.preAdoption,
+    snapshots.endOfObservation,
+  ),
+];
+
+const historicCohorts = evidence.activity.historicCohorts;
+const formatCoverage = (percent: number) => `${percent.toFixed(3)}%`;
+
+export const historicDeliveryAndCoverage = [2022, 2023, 2024].map((year) => {
+  const cohort = historicCohorts[String(year) as "2022" | "2023" | "2024"];
+  const coverage = cohort.coverage;
+  if ("status" in coverage) {
+    return {
+      year,
+      ...cohort,
+      coverageDisplay: `Not available → ${formatCoverage(coverage.end.coveredPercent)}`,
+      coverageChange: "Not estimable",
+      coverageNote: coverage.reason,
+    };
+  }
+  const change = Number(
+    (coverage.end.coveredPercent - coverage.start.coveredPercent).toFixed(3),
+  );
+  return {
+    year,
+    ...cohort,
+    coverageDisplay: `${formatCoverage(coverage.start.coveredPercent)} → ${formatCoverage(coverage.end.coveredPercent)}`,
+    coverageChange: `${displaySignedChange(change)} percentage points`,
+  };
+});
+
+const historicDefectCohorts = evidence.activity.historicDefectCohorts;
+
+export const historicDefectSummaries = [2022, 2023, 2024].map((year) => {
+  const cohort =
+    historicDefectCohorts[String(year) as "2022" | "2023" | "2024"];
+  return {
+    year,
+    ...cohort,
+    responseDisplay:
+      cohort.medianResponseDays === null
+        ? "Not estimable"
+        : `${cohort.medianResponseDays} days`,
+    introducedDisplay:
+      cohort.introducedReports.length === 0
+        ? "None observed"
+        : cohort.introducedReports.map((report) => `#${report.number}`).join(", "),
+  };
+});
+
+const numberRange = (values: number[]) => ({
+  minimum: Math.min(...values),
+  maximum: Math.max(...values),
+});
+const displayNumber = (value: number, maximumFractionDigits = 2) =>
+  value.toLocaleString("en-US", { maximumFractionDigits });
+const displayRange = (values: number[], suffix = "") => {
+  const range = numberRange(values);
+  return `${displayNumber(range.minimum)}–${displayNumber(range.maximum)}${suffix}`;
+};
+const baselineRow = (
+  label: string,
+  years: string,
+  historicalValues: number[],
+  actual: number,
+  suffix = "",
+  note?: string,
+) => {
+  const benchmark = median(historicalValues);
+  const difference = actual - benchmark;
+  return {
+    label,
+    historicalBasis: `${years}; range ${displayRange(historicalValues, suffix)}`,
+    benchmark,
+    actual,
+    difference,
+    displayBenchmark: `${displayNumber(benchmark)}${suffix}`,
+    displayActual: `${displayNumber(actual)}${suffix}`,
+    displayDifference: `${difference >= 0 ? "+" : ""}${displayNumber(difference)}${suffix}`,
+    note,
+  };
+};
+
+const historicalDeliveryValues = [
+  historicCohorts["2022"],
+  historicCohorts["2023"],
+  historicCohorts["2024"],
+];
+const testGrowthValues = [
+  cohortAddition(
+    "2023",
+    comparison2023Snapshots.start,
+    comparison2023Snapshots.end,
+  ),
+  cohortAddition(
+    "2024",
+    comparison2024Snapshots.start,
+    comparison2024Snapshots.end,
+  ),
+  cohortAddition(
+    "2025",
+    comparison2025Snapshots.start,
+    comparison2025Snapshots.end,
+  ),
+];
+const historicalDefectValues = [
+  historicDefectCohorts["2022"],
+  historicDefectCohorts["2023"],
+  historicDefectCohorts["2024"],
+];
+const comparison2025 = primaryComparisonSummary.find(
+  (cohort) => cohort.year === 2025,
+)!;
+const actual2026 = primaryComparisonSummary.find(
+  (cohort) => cohort.year === 2026,
+)!;
+
+const pooledHistoricalIntroductions =
+  historicalDefectValues.reduce(
+    (total, cohort) => total + cohort.introducedWithinWindow,
+    0,
+  ) + comparison2025.introduced;
+const pooledHistoricalMerges =
+  historicalDeliveryValues.reduce(
+    (total, cohort) => total + cohort.nonDependencyMergedPullRequests,
+    0,
+  ) + comparison2025.nonDependencyMerges;
+export const pooledHistoricalIntroducedRatePer100 =
+  (pooledHistoricalIntroductions / pooledHistoricalMerges) * 100;
+export const exposureScaledIntroducedBenchmark =
+  (pooledHistoricalIntroductions / pooledHistoricalMerges) *
+  actual2026.nonDependencyMerges;
+
+export const retrospectiveBaselineRows = [
+  baselineRow(
+    "Non-dependency merged PRs",
+    "2022–2025",
+    [
+      ...historicalDeliveryValues.map(
+        (cohort) => cohort.nonDependencyMergedPullRequests,
+      ),
+      comparison2025.nonDependencyMerges,
+    ],
+    actual2026.nonDependencyMerges,
+  ),
+  baselineRow(
+    "Published releases",
+    "2022–2025",
+    [
+      ...historicalDeliveryValues.map((cohort) => cohort.publishedReleases),
+      comparison2025.releases,
+    ],
+    evidence.activity.primaryWindow.publishedReleases["2026"],
+  ),
+  baselineRow(
+    "Test files added",
+    "2023–2025",
+    testGrowthValues.map((cohort) => cohort.testFilesAdded),
+    snapshots.endOfObservation.testFiles - snapshots.preAdoption.testFiles,
+  ),
+  baselineRow(
+    "Test declarations added",
+    "2023–2025",
+    testGrowthValues.map((cohort) => cohort.declarationsAdded),
+    snapshots.endOfObservation.testDeclarations -
+      snapshots.preAdoption.testDeclarations,
+  ),
+  baselineRow(
+    "Qualifying external product-defect reports",
+    "2022–2025",
+    [
+      ...historicalDefectValues.map(
+        (cohort) => cohort.qualifyingExternalProductDefects,
+      ),
+      comparison2025.totalReports,
+    ],
+    actual2026.totalReports,
+  ),
+  {
+    ...baselineRow(
+      "Median report-to-release time",
+      "2023–2025 cohort medians",
+      [
+        historicDefectCohorts["2023"].medianResponseDays!,
+        historicDefectCohorts["2024"].medianResponseDays!,
+        comparison2025.medianResponseDays,
+      ],
+      actual2026.medianResponseDays,
+      " days",
+    ),
+    displayActual: `${actual2026.medianResponseDays} day`,
+  },
+  {
+    label: "Introduced qualifying reports, exposure-scaled",
+    historicalBasis: `${pooledHistoricalIntroductions} reports / ${pooledHistoricalMerges} non-dependency PRs (${pooledHistoricalIntroducedRatePer100.toFixed(2)} per 100)`,
+    benchmark: exposureScaledIntroducedBenchmark,
+    actual: actual2026.introduced,
+    difference: actual2026.introduced - exposureScaledIntroducedBenchmark,
+    displayBenchmark: exposureScaledIntroducedBenchmark.toFixed(2),
+    displayActual: String(actual2026.introduced),
+    displayDifference: (actual2026.introduced - exposureScaledIntroducedBenchmark).toFixed(2),
+    note: `Expected-value benchmark after scaling the pooled historical rate to ${actual2026.nonDependencyMerges} observed 2026 non-dependency PRs.`,
+  },
+];
+
+const completeHistoricalCoverageChanges = ["2023", "2024"].map((year) => {
+  const coverage = historicCohorts[year as "2023" | "2024"].coverage;
+  return coverage.end.coveredPercent - coverage.start.coveredPercent;
+});
+const coverageReferenceMidpoint = median(completeHistoricalCoverageChanges);
+const actualCoverageChange =
+  snapshots.endOfObservation.lineCoveragePercent -
+  snapshots.preAdoption.lineCoveragePercent;
+export const coverageReference = {
+  historicalYears: "2023–2024",
+  midpoint: coverageReferenceMidpoint,
+  actual: actualCoverageChange,
+  difference: actualCoverageChange - coverageReferenceMidpoint,
+  displayMidpoint: `${displaySignedChange(Number(coverageReferenceMidpoint.toFixed(3)))} percentage points`,
+  displayRange: `${displayNumber(Math.min(...completeHistoricalCoverageChanges), 3)} to ${displayNumber(Math.max(...completeHistoricalCoverageChanges), 3)} percentage points`,
+  displayActual: `${displaySignedChange(Number(actualCoverageChange.toFixed(3)))} percentage points`,
+  displayDifference: `${displaySignedChange(Number((actualCoverageChange - coverageReferenceMidpoint).toFixed(3)))} percentage points`,
+};
+
+const cohortGitMetrics = evidence.activity.cohortGitMetrics.cohorts;
+export const gitCohortMetrics = [2022, 2023, 2024, 2025, 2026].map((year) => ({
+  year,
+  ...cohortGitMetrics[String(year) as "2022" | "2023" | "2024" | "2025" | "2026"],
+}));
+
+const completePreAiGitCohorts = [
+  cohortGitMetrics["2023"],
+  cohortGitMetrics["2024"],
+  cohortGitMetrics["2025"],
+];
+export const gitHistoricalBaselineRows = [
+  baselineRow(
+    "First-parent commits",
+    "2023–2025",
+    completePreAiGitCohorts.map((cohort) => cohort.firstParentCommits),
+    cohortGitMetrics["2026"].firstParentCommits,
+  ),
+  baselineRow(
+    "Total textual churn",
+    "2023–2025",
+    completePreAiGitCohorts.map((cohort) => cohort.churn),
+    cohortGitMetrics["2026"].churn,
+    " lines",
+  ),
+  baselineRow(
+    "Test churn",
+    "2023–2025",
+    completePreAiGitCohorts.map((cohort) => cohort.categoryChurn.tests),
+    cohortGitMetrics["2026"].categoryChurn.tests,
+    " lines",
+  ),
+  baselineRow(
+    "Docs/site churn",
+    "2023–2025",
+    completePreAiGitCohorts.map(
+      (cohort) => cohort.categoryChurn.documentation,
+    ),
+    cohortGitMetrics["2026"].categoryChurn.documentation,
+    " lines",
+  ),
+  baselineRow(
+    "Lock/generated churn",
+    "2023–2025",
+    completePreAiGitCohorts.map(
+      (cohort) => cohort.categoryChurn.lockOrGenerated,
+    ),
+    cohortGitMetrics["2026"].categoryChurn.lockOrGenerated,
+    " lines",
+  ),
+  baselineRow(
+    "Source/other churn",
+    "2023–2025",
+    completePreAiGitCohorts.map(
+      (cohort) => cohort.categoryChurn.sourceOrOther,
+    ),
+    cohortGitMetrics["2026"].categoryChurn.sourceOrOther,
+    " lines",
+  ),
+];
 
 export const deliveryMetrics = [
   {

--- a/site/src/data/quality-audit-evidence.json
+++ b/site/src/data/quality-audit-evidence.json
@@ -23,6 +23,20 @@
         "endExclusive": "2026-09-04T00:00:00Z"
       }
     },
+    "historicalWindows": {
+      "2022": {
+        "start": "2022-03-10T16:38:20Z",
+        "endExclusive": "2022-09-04T00:00:00Z"
+      },
+      "2023": {
+        "start": "2023-03-10T16:38:20Z",
+        "endExclusive": "2023-09-04T00:00:00Z"
+      },
+      "2024": {
+        "start": "2024-03-10T16:38:20Z",
+        "endExclusive": "2024-09-04T00:00:00Z"
+      }
+    },
     "supplementalWindows": {
       "2025": {
         "start": "2025-01-01T00:00:00Z",
@@ -37,7 +51,14 @@
       "Externally reported product defects introduced during the comparison window per 100 non-dependency merged pull requests.",
       "Median calendar days from qualifying report to first public release containing the correction.",
       "Automated test-file count, explicit test declarations, and reported line coverage at the pre-adoption and end-of-observation snapshots."
-    ]
+    ],
+    "retrospectiveComparison": {
+      "constructedAfterObservation": true,
+      "ordinaryMeasureRule": "Use the median and observed range of every pre-AI cohort with a complete comparable measurement.",
+      "introducedDefectRule": "Pool qualifying within-window introductions and non-dependency merged pull requests across every eligible pre-AI cohort, then apply that rate to the observed 2026 exposure.",
+      "coverageRule": "Treat the midpoint of the two complete pre-AI coverage changes as a descriptive reference, not a forecast.",
+      "interpretation": "Descriptive historical baselines, not prospective predictions, prediction intervals, causal estimates, or estimates of what necessarily would have happened without AI."
+    }
   },
   "maturityDays": 90,
   "populationRules": {
@@ -46,6 +67,12 @@
     "process": "Release-integrity and workflow failures are recorded separately from product defects."
   },
   "queries": [
+    "repo:counterfact/api-simulator is:issue created:2022-03-10..2022-09-03",
+    "repo:counterfact/api-simulator is:pr created:2022-03-10..2022-09-03",
+    "repo:counterfact/api-simulator is:issue created:2023-03-10..2023-09-03",
+    "repo:counterfact/api-simulator is:pr created:2023-03-10..2023-09-03",
+    "repo:counterfact/api-simulator is:issue created:2024-03-10..2024-09-03",
+    "repo:counterfact/api-simulator is:pr created:2024-03-10..2024-09-03",
     "repo:counterfact/api-simulator is:issue created:2025-01-01..2025-09-03",
     "repo:counterfact/api-simulator is:pr created:2025-01-01..2025-09-03",
     "repo:counterfact/api-simulator is:issue created:2026-01-01..2026-09-03",
@@ -66,8 +93,24 @@
     "npm --prefix site run verify:audit",
     "gh search prs --repo counterfact/api-simulator --merged --merged-at 2025-03-10..2025-09-03 --limit 1000 --json number,author,closedAt,title",
     "gh search prs --repo counterfact/api-simulator --merged --merged-at 2026-03-10..2026-09-03 --limit 1000 --json number,author,closedAt,title",
+    "gh search prs --repo counterfact/api-simulator --merged --merged-at 2022-03-10..2022-09-03 --limit 1000 --json number,author,closedAt,title",
+    "gh search prs --repo counterfact/api-simulator --merged --merged-at 2023-03-10..2023-09-03 --limit 1000 --json number,author,closedAt,title",
+    "gh search prs --repo counterfact/api-simulator --merged --merged-at 2024-03-10..2024-09-03 --limit 1000 --json number,author,closedAt,title",
+    "curl -fsSL https://coveralls.io/builds/13c246c1795e66cffc1a0e022b407660ec384b02.json",
+    "curl -fsSL https://coveralls.io/builds/06c354e0f30d52776006929f7c7e657520adf330.json",
+    "curl -fsSL https://coveralls.io/builds/061d88e7ba072dbfa931ec306b4e6ae94f32b155.json",
+    "curl -fsSL https://coveralls.io/builds/f17e758dbf87d58fb09e8910190d590c216609e5.json",
+    "curl -fsSL https://coveralls.io/builds/7eaccb20ae8f26e4b767dfb9f4f9e92b09623744.json",
+    "npm --prefix site run snapshot:audit -- 13c246c1795e66cffc1a0e022b407660ec384b02",
+    "npm --prefix site run snapshot:audit -- 06c354e0f30d52776006929f7c7e657520adf330",
+    "npm --prefix site run snapshot:audit -- 061d88e7ba072dbfa931ec306b4e6ae94f32b155",
+    "npm --prefix site run snapshot:audit -- f17e758dbf87d58fb09e8910190d590c216609e5",
+    "npm --prefix site run snapshot:audit -- 7eaccb20ae8f26e4b767dfb9f4f9e92b09623744",
+    "npm --prefix site run snapshot:audit -- d8eeb73d6a16f266719384f7c6ef5b3a1f556e4b",
+    "npm --prefix site run snapshot:audit -- 939d149f753edcc0c2de10db1afb60c335840231",
     "npm --prefix site run snapshot:audit -- 68a3f505ce457f10e4ab30dea47ed8fdde2eb48a",
-    "npm --prefix site run snapshot:audit -- 77f0bc6fd2c3bc935d2eb2da80190369d91f7084"
+    "npm --prefix site run snapshot:audit -- 77f0bc6fd2c3bc935d2eb2da80190369d91f7084",
+    "npm --prefix site run snapshot:churn -- 77f0bc6fd2c3bc935d2eb2da80190369d91f7084"
   ],
   "candidates": [
     {
@@ -844,7 +887,280 @@
         }
       }
     },
+    "historicCohorts": {
+      "2022": {
+        "mergedPullRequests": 108,
+        "dependencyBotPullRequests": 45,
+        "nonDependencyMergedPullRequests": 63,
+        "publishedReleases": 7,
+        "coverage": {
+          "status": "not_estimable",
+          "reason": "The March boundary predates main-reachable history and the first reachable commit has no Coveralls build.",
+          "end": {
+            "commit": "13c246c1795e66cffc1a0e022b407660ec384b02",
+            "coveredPercent": 92.0652173913044,
+            "source": "https://coveralls.io/builds/52174439"
+          }
+        }
+      },
+      "2023": {
+        "mergedPullRequests": 128,
+        "dependencyBotPullRequests": 78,
+        "nonDependencyMergedPullRequests": 50,
+        "publishedReleases": 19,
+        "coverage": {
+          "start": {
+            "commit": "06c354e0f30d52776006929f7c7e657520adf330",
+            "coveredPercent": 87.4656188605108,
+            "source": "https://coveralls.io/builds/57532255"
+          },
+          "end": {
+            "commit": "061d88e7ba072dbfa931ec306b4e6ae94f32b155",
+            "coveredPercent": 85.17208105500161,
+            "source": "https://coveralls.io/builds/62400840"
+          }
+        }
+      },
+      "2024": {
+        "mergedPullRequests": 199,
+        "dependencyBotPullRequests": 124,
+        "nonDependencyMergedPullRequests": 75,
+        "publishedReleases": 24,
+        "coverage": {
+          "start": {
+            "commit": "f17e758dbf87d58fb09e8910190d590c216609e5",
+            "coveredPercent": 86.227261989133,
+            "source": "https://coveralls.io/builds/66186038"
+          },
+          "end": {
+            "commit": "7eaccb20ae8f26e4b767dfb9f4f9e92b09623744",
+            "coveredPercent": 82.59851736246586,
+            "source": "https://coveralls.io/builds/69559350"
+          }
+        }
+      }
+    },
+    "cohortGitMetrics": {
+      "analysisRef": "77f0bc6fd2c3bc935d2eb2da80190369d91f7084",
+      "clock": "committer timestamp",
+      "algorithm": {
+        "window": "March 10 at 16:38:20 UTC, inclusive, through September 4 at 00:00 UTC, exclusive.",
+        "headlineCommitPopulation": "First-parent commits reachable from main.",
+        "headlineChurnComparison": "Each selected first-parent commit compared with its first parent; a selected root commit is compared with the empty tree.",
+        "renameDetection": "git diff -M",
+        "binaryHandling": "Binary file touches are counted but omitted from textual line totals.",
+        "categoryPriority": [
+          "lockfiles/generated",
+          "tests",
+          "docs/site",
+          "source/other"
+        ]
+      },
+      "cohorts": {
+        "2022": {
+          "status": "partial_history",
+          "reason": "The first main-reachable commit is April 8, after the March 10 cohort boundary.",
+          "firstIncludedCommit": "238c74baa4748932dc5580cc0a18016b9442d21e",
+          "lastIncludedCommit": "13c246c1795e66cffc1a0e022b407660ec384b02",
+          "firstParentCommits": 181,
+          "additions": 42770,
+          "deletions": 9252,
+          "churn": 52022,
+          "fileTouchOccurrences": 724,
+          "binaryFileTouchOccurrences": 0,
+          "renamedFileOccurrences": 31,
+          "categoryChurn": {
+            "tests": 18097,
+            "documentation": 1948,
+            "lockOrGenerated": 24429,
+            "sourceOrOther": 7548
+          }
+        },
+        "2023": {
+          "firstIncludedCommit": "25deaabd21aff38d5701a712f4a61455d3b13620",
+          "lastIncludedCommit": "061d88e7ba072dbfa931ec306b4e6ae94f32b155",
+          "firstParentCommits": 129,
+          "additions": 7535,
+          "deletions": 5036,
+          "churn": 12571,
+          "fileTouchOccurrences": 378,
+          "binaryFileTouchOccurrences": 0,
+          "renamedFileOccurrences": 0,
+          "categoryChurn": {
+            "tests": 1782,
+            "documentation": 514,
+            "lockOrGenerated": 8672,
+            "sourceOrOther": 1603
+          }
+        },
+        "2024": {
+          "firstIncludedCommit": "a586be5e659cdf95a519cefd301946ad47899a4a",
+          "lastIncludedCommit": "7eaccb20ae8f26e4b767dfb9f4f9e92b09623744",
+          "firstParentCommits": 205,
+          "additions": 163929,
+          "deletions": 165287,
+          "churn": 329216,
+          "fileTouchOccurrences": 747,
+          "binaryFileTouchOccurrences": 0,
+          "renamedFileOccurrences": 2,
+          "categoryChurn": {
+            "tests": 11582,
+            "documentation": 1070,
+            "lockOrGenerated": 312983,
+            "sourceOrOther": 3581
+          },
+          "note": "Raw churn includes a 148,049-line Yarn artifact added and later removed; it remains in lock/generated, not source/other."
+        },
+        "2025": {
+          "firstIncludedCommit": "66d68a7ddcd6f0a9354146bb13d1aedb1c486dc3",
+          "lastIncludedCommit": "939d149f753edcc0c2de10db1afb60c335840231",
+          "firstParentCommits": 152,
+          "additions": 9714,
+          "deletions": 7256,
+          "churn": 16970,
+          "fileTouchOccurrences": 336,
+          "binaryFileTouchOccurrences": 0,
+          "renamedFileOccurrences": 0,
+          "categoryChurn": {
+            "tests": 409,
+            "documentation": 131,
+            "lockOrGenerated": 15665,
+            "sourceOrOther": 765
+          }
+        },
+        "2026": {
+          "firstIncludedCommit": "d244e0140aa4d1e315aeec2369e00b16c8ff7a49",
+          "lastIncludedCommit": "77f0bc6fd2c3bc935d2eb2da80190369d91f7084",
+          "firstParentCommits": 548,
+          "additions": 104938,
+          "deletions": 46409,
+          "churn": 151347,
+          "fileTouchOccurrences": 3182,
+          "binaryFileTouchOccurrences": 0,
+          "renamedFileOccurrences": 275,
+          "categoryChurn": {
+            "tests": 30867,
+            "documentation": 37671,
+            "lockOrGenerated": 58167,
+            "sourceOrOther": 24642
+          }
+        }
+      }
+    },
+    "historicDefectCohorts": {
+      "2022": {
+        "reviewedIssues": 54,
+        "reviewedPullRequests": 119,
+        "qualifyingExternalProductDefects": 0,
+        "introducedWithinWindow": 0,
+        "preExistingOrPreWindow": 0,
+        "medianResponseDays": null,
+        "introducedReports": [],
+        "note": "No qualifying external product-defect reports were observed. The empty cohort has no report-to-release median."
+      },
+      "2023": {
+        "reviewedIssues": 12,
+        "reviewedPullRequests": 140,
+        "qualifyingExternalProductDefects": 5,
+        "introducedWithinWindow": 1,
+        "preExistingOrPreWindow": 4,
+        "medianResponseDays": 5,
+        "introducedReports": [
+          {
+            "number": 491,
+            "title": "Quick Start broke generated TypeScript loading",
+            "sourceUrl": "https://github.com/counterfact/api-simulator/issues/491",
+            "firstAffectedRelease": "0.20.4",
+            "firstAffectedCommit": "b69914f19fd8cd8a35ef4513a3b34d8c81718bb2"
+          }
+        ]
+      },
+      "2024": {
+        "reviewedIssues": 36,
+        "reviewedPullRequests": 206,
+        "qualifyingExternalProductDefects": 7,
+        "introducedWithinWindow": 3,
+        "preExistingOrPreWindow": 4,
+        "medianResponseDays": 6,
+        "introducedReports": [
+          {
+            "number": 866,
+            "title": "Package postinstall required an unavailable dependency",
+            "sourceUrl": "https://github.com/counterfact/api-simulator/issues/866",
+            "firstAffectedRelease": "0.39.0",
+            "firstAffectedCommit": "c4dda369fb51fcfa072a49b5a23dc9143b57c9e8"
+          },
+          {
+            "number": 906,
+            "title": "CJS hot reload failed for extensionless local imports",
+            "sourceUrl": "https://github.com/counterfact/api-simulator/issues/906",
+            "firstAffectedRelease": "0.40.0",
+            "firstAffectedCommit": "485bd42365bbf55d7a695fcd6da0d5de26550652"
+          },
+          {
+            "number": 918,
+            "title": "Operation return typing made the JSON shortcut incomplete",
+            "sourceUrl": "https://github.com/counterfact/api-simulator/issues/918",
+            "firstAffectedRelease": "0.38.0",
+            "firstAffectedCommit": "9e7923c219b4da73be701803632525d1ae63d4c6"
+          }
+        ],
+        "note": "One additional OpenAPI 3.1 report, #1005, is excluded as unsupported new capability; including it changes neither the within-window introduction count nor the conclusion."
+      }
+    },
     "snapshots": {
+      "comparison2022": {
+        "status": "not_estimable",
+        "reason": "The first main-reachable commit is 238c74baa4748932dc5580cc0a18016b9442d21e on April 8, 2022, after the March 10 start boundary.",
+        "end": {
+          "commit": "13c246c1795e66cffc1a0e022b407660ec384b02",
+          "observedAt": "2022-09-04T00:00:00Z",
+          "testFiles": 21,
+          "testDeclarations": 94
+        }
+      },
+      "comparison2023": {
+        "start": {
+          "commit": "06c354e0f30d52776006929f7c7e657520adf330",
+          "observedAt": "2023-03-10T16:38:20Z",
+          "testFiles": 24,
+          "testDeclarations": 137
+        },
+        "end": {
+          "commit": "061d88e7ba072dbfa931ec306b4e6ae94f32b155",
+          "observedAt": "2023-09-04T00:00:00Z",
+          "testFiles": 24,
+          "testDeclarations": 147
+        }
+      },
+      "comparison2024": {
+        "start": {
+          "commit": "f17e758dbf87d58fb09e8910190d590c216609e5",
+          "observedAt": "2024-03-10T16:38:20Z",
+          "testFiles": 28,
+          "testDeclarations": 175
+        },
+        "end": {
+          "commit": "7eaccb20ae8f26e4b767dfb9f4f9e92b09623744",
+          "observedAt": "2024-09-04T00:00:00Z",
+          "testFiles": 34,
+          "testDeclarations": 223
+        }
+      },
+      "comparison2025": {
+        "start": {
+          "commit": "d8eeb73d6a16f266719384f7c6ef5b3a1f556e4b",
+          "observedAt": "2025-03-10T16:38:20Z",
+          "testFiles": 34,
+          "testDeclarations": 233
+        },
+        "end": {
+          "commit": "939d149f753edcc0c2de10db1afb60c335840231",
+          "observedAt": "2025-09-04T00:00:00Z",
+          "testFiles": 35,
+          "testDeclarations": 239
+        }
+      },
       "preAdoption": {
         "commit": "68a3f505ce457f10e4ab30dea47ed8fdde2eb48a",
         "observedAt": "2026-03-10T16:38:19Z",

--- a/site/src/pages/quality/2026/context.astro
+++ b/site/src/pages/quality/2026/context.astro
@@ -2,8 +2,15 @@
 import QualityLayout from "../../../layouts/QualityLayout.astro";
 import {
   auditEvidence,
+  coverageReference,
   deliveryMetrics,
   featureTimeline,
+  gitCohortMetrics,
+  gitHistoricalBaselineRows,
+  historicDefectSummaries,
+  historicDeliveryAndCoverage,
+  retrospectiveBaselineRows,
+  testCohortAdditions,
   testingMetrics,
 } from "../../../data/quality-2026";
 
@@ -56,15 +63,68 @@ const adoption = auditEvidence.activity.adoption;
       remained subject to maintainer review and release decisions.
     </p>
 
+    <h2>Earlier matched-window delivery and coverage</h2>
+    <p>
+      The following historical context uses the same March 10–September 3 window.
+      It is descriptive only: these cohorts predate the intervention and are not
+      estimates of an AI effect.
+    </p>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Cohort</th><th scope="col">All merged PRs</th><th scope="col">Non-dependency merged PRs</th><th scope="col">Published releases</th><th scope="col">Coveralls line coverage, start → end</th><th scope="col">Coverage change</th></tr></thead>
+        <tbody>
+          {historicDeliveryAndCoverage.map((cohort) => (
+            <tr><th scope="row">{cohort.year}{cohort.coverageNote && <span class="cell-detail">{cohort.coverageNote}</span>}</th><td>{cohort.mergedPullRequests}</td><td>{cohort.nonDependencyMergedPullRequests}</td><td>{cohort.publishedReleases}</td><td>{cohort.coverageDisplay}</td><td>{cohort.coverageChange}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      Coveralls values are the historical CI results, not a coverage recomputation
+      with a modern toolchain. Dependency-only pull requests are excluded only
+      from the non-dependency column; all merged pull requests remain visible for
+      context.
+    </p>
+
+    <h2>Earlier externally reported product defects</h2>
+    <p>
+      These complete public GitHub issue and pull-request censuses use the same
+      exact window. A reported defect counts as introduced only when the first
+      confirmed affected public release also fell within that year’s window.
+    </p>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Cohort</th><th scope="col">Issues / PRs reviewed</th><th scope="col">Qualifying external product-defect reports</th><th scope="col">First introduced during window</th><th scope="col">Reported defects predating window</th><th scope="col">Median report-to-release</th></tr></thead>
+        <tbody>
+          {historicDefectSummaries.map((cohort) => (
+            <tr><th scope="row">{cohort.year}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th><td>{cohort.reviewedIssues} / {cohort.reviewedPullRequests}</td><td>{cohort.qualifyingExternalProductDefects}</td><td>{cohort.introducedReports.length === 0 ? cohort.introducedDisplay : cohort.introducedReports.map((report) => <><a href={report.sourceUrl}>#{report.number}</a>{" "}</>)}</td><td>{cohort.preExistingOrPreWindow}</td><td>{cohort.responseDisplay}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      The 2023 within-window introduction was <a href="https://github.com/counterfact/api-simulator/issues/491">#491</a>, first released in 0.20.4. The 2024 introductions were <a href="https://github.com/counterfact/api-simulator/issues/866">#866</a> (0.39.0), <a href="https://github.com/counterfact/api-simulator/issues/906">#906</a> (0.40.0), and <a href="https://github.com/counterfact/api-simulator/issues/918">#918</a> (0.38.0). Their source history and the exact census queries are retained in the machine-readable evidence manifest.
+    </p>
+
     <h2>Automated verification snapshots</h2>
     <table class="research-table">
-      <thead><tr><th scope="col">Measure</th><th scope="col">Before adoption</th><th scope="col">September 3</th></tr></thead>
+      <thead><tr><th scope="col">Measure</th><th scope="col">Before adoption</th><th scope="col">September 3</th><th scope="col">Change during AI cohort</th></tr></thead>
       <tbody>
         {testingMetrics.map((metric) => (
-          <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td></tr>
+          <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td><td>{metric.displayChange}</td></tr>
         ))}
       </tbody>
     </table>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Files added</th><th scope="col">Declarations, start → end</th><th scope="col">Declarations added</th></tr></thead>
+        <tbody>
+          {testCohortAdditions.map((cohort) => (
+            <tr><th scope="row">{cohort.label}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th><td>{cohort.displayTestFiles}</td><td>{cohort.displayTestFilesAdded}</td><td>{cohort.displayDeclarations}</td><td>{cohort.displayDeclarationsAdded}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
     <p>
       The file count includes JavaScript and TypeScript files containing at least
       one explicit <code>it</code> or <code>test</code> declaration, plus Python
@@ -81,6 +141,122 @@ const adoption = auditEvidence.activity.adoption;
       at the observation endpoint. During that interval the project was reorganized
       into multiple packages, so the percentages are real results over changing
       source sets rather than a controlled measurement over identical files.
+    </p>
+
+    <h2>Commit and line-change activity</h2>
+    <p>
+      The audit now counts first-parent commits and cumulative textual changes on{" "}
+      <code>main</code>. Each mainline integration is compared only with its first
+      parent, so a merged topic branch is counted once. The analysis is pinned to
+      the audit’s immutable September 3 observation commit.
+    </p>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Cohort</th><th scope="col">First-parent commits</th><th scope="col">Lines added</th><th scope="col">Lines deleted</th><th scope="col">Total churn</th><th scope="col">File-touch occurrences</th></tr></thead>
+        <tbody>
+          {gitCohortMetrics.map((cohort) => (
+            <tr>
+              <th scope="row">{cohort.year}{cohort.year === 2026 && " AI cohort"}{"status" in cohort && <span class="cell-detail">{cohort.reason}</span>}</th>
+              <td>{cohort.firstParentCommits.toLocaleString()}</td>
+              <td>{cohort.additions.toLocaleString()}</td>
+              <td>{cohort.deletions.toLocaleString()}</td>
+              <td>{cohort.churn.toLocaleString()}</td>
+              <td>{cohort.fileTouchOccurrences.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Cohort</th><th scope="col">Test churn</th><th scope="col">Docs/site churn</th><th scope="col">Lock/generated churn</th><th scope="col">Source/other churn</th></tr></thead>
+        <tbody>
+          {gitCohortMetrics.map((cohort) => (
+            <tr>
+              <th scope="row">{cohort.year}{cohort.year === 2026 && " AI cohort"}</th>
+              <td>{cohort.categoryChurn.tests.toLocaleString()}</td>
+              <td>{cohort.categoryChurn.documentation.toLocaleString()}</td>
+              <td>{cohort.categoryChurn.lockOrGenerated.toLocaleString()}</td>
+              <td>{cohort.categoryChurn.sourceOrOther.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      Churn is additions plus deletions, not effort or product value. File-touch
+      occurrences count a path once per first-parent commit, not distinct files.
+      Categories are deterministic path rules applied in this order: lockfiles and
+      generated files, tests, docs/site, then source/other. The 2024 raw total is
+      dominated by a 148,049-line Yarn artifact that was added and later removed;
+      it is classified as lock/generated. The 2022 row covers only reachable
+      history beginning April 8 and is excluded from repository-derived baselines.
+    </p>
+
+    <h2>Retrospective historical-baseline comparison</h2>
+    <p>
+      These baselines were constructed after the 2026 outcomes were known. They
+      summarize matched pre-AI cohorts and provide descriptive points of
+      comparison; they are not prospective predictions, prediction intervals,
+      causal estimates, or estimates of what necessarily would have happened
+      without AI. Each measure uses every pre-AI cohort with a complete comparable
+      observation.
+    </p>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Measure</th><th scope="col">Historical basis</th><th scope="col">2026 benchmark</th><th scope="col">2026 observed</th><th scope="col">Observed − benchmark</th></tr></thead>
+        <tbody>
+          {retrospectiveBaselineRows.map((row) => (
+            <tr>
+              <th scope="row">{row.label}{row.note && <span class="cell-detail">{row.note}</span>}</th>
+              <td>{row.historicalBasis}</td>
+              <td>{row.displayBenchmark}</td>
+              <td>{row.displayActual}</td>
+              <td>{row.displayDifference}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      “Historical range” is the minimum and maximum of the eligible pre-AI
+      cohorts, not a statistical confidence or prediction interval. The
+      exposure-scaled defect benchmark applies the pooled pre-AI rate—four
+      qualifying within-window introductions across 203 non-dependency merged
+      PRs, or 1.97 per 100—to the 281 observed 2026 PRs. The resulting 5.54 is an
+      expected-value benchmark, not a claim that 5.54 defects necessarily existed
+      or that AI prevented them. No significance test is claimed.
+    </p>
+    <table class="research-table">
+      <thead><tr><th scope="col">Coverage comparison</th><th scope="col">Value</th></tr></thead>
+      <tbody>
+        <tr><th scope="row">Two-cohort pre-AI reference midpoint<span class="cell-detail">2023–2024 only; not a forecast.</span></th><td>{coverageReference.displayMidpoint}</td></tr>
+        <tr><th scope="row">Observed pre-AI range</th><td>{coverageReference.displayRange}</td></tr>
+        <tr><th scope="row">Observed 2026 change</th><td>{coverageReference.displayActual}</td></tr>
+        <tr><th scope="row">Observed minus reference midpoint</th><td>{coverageReference.displayDifference}</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Coverage has only two complete comparable pre-AI changes, and the 2026
+      package reorganization changed its denominator. The midpoint is therefore
+      reference context only. Commit and churn medians are likewise additional
+      workload context, not inputs to the defect-rate benchmark:
+    </p>
+    <div class="table-scroll">
+      <table class="research-table">
+        <thead><tr><th scope="col">Workload measure</th><th scope="col">Historical basis</th><th scope="col">2026 benchmark</th><th scope="col">2026 observed</th><th scope="col">Observed − benchmark</th></tr></thead>
+        <tbody>
+          {gitHistoricalBaselineRows.map((row) => (
+            <tr><th scope="row">{row.label}</th><td>{row.historicalBasis}</td><td>{row.displayBenchmark}</td><td>{row.displayActual}</td><td>{row.displayDifference}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      Only 2023–2025 contribute to those repository-derived medians. Three
+      observations, differing merge strategies, mechanical changes, and the 2026
+      package reorganization do not support a stable churn-adjusted quality model.
+      Non-dependency merged PRs remain the audit’s declared exposure denominator.
     </p>
 
     <h2>Full-window sensitivity measurements</h2>

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -3,7 +3,10 @@ import QualityLayout from "../../../layouts/QualityLayout.astro";
 import {
   auditEvidence,
   comparisonSummary,
+  gitHistoricalBaselineRows,
   primaryComparisonSummary,
+  retrospectiveBaselineRows,
+  testCohortAdditions,
   testingMetrics,
 } from "../../../data/quality-2026";
 
@@ -12,6 +15,12 @@ const after = primaryComparisonSummary[1];
 const snapshots = auditEvidence.activity.snapshots;
 const fullBefore = comparisonSummary[0];
 const fullAfter = comparisonSummary[1];
+const historicalBaseline = Object.fromEntries(
+  retrospectiveBaselineRows.map((row) => [row.label, row]),
+);
+const gitBaseline = Object.fromEntries(
+  gitHistoricalBaselineRows.map((row) => [row.label, row]),
+);
 ---
 
 <QualityLayout
@@ -83,6 +92,8 @@ const fullAfter = comparisonSummary[1];
           <a href={auditEvidence.study.intervention.source}>the first agent-authored
           product change merged to <code>main</code></a> on March 10, 2026. The
           primary comparison uses the same March 10–September 3 interval in 2025.
+          Additional matched cohorts in 2022–2024 provide historical context, with
+          each measure using only years that have a complete comparable observation.
           The broader January 1–September 3 cohorts remain as a sensitivity check.
         </p>
         <p>
@@ -201,7 +212,8 @@ const fullAfter = comparisonSummary[1];
         <h2 id="verification-heading">Automated verification expanded</h2>
         <p>
           Figure 1. Repository snapshots immediately before the first agent-authored
-          merge and at the September 3 observation point.
+          merge and at the September 3 observation point. The cohort table uses the
+          same March–September span in earlier years where repository history permits.
         </p>
       </figcaption>
       <div class="comparison-bars">
@@ -210,7 +222,7 @@ const fullAfter = comparisonSummary[1];
             <div class="comparison-measure">
               <div class="comparison-label">
                 <strong>{metric.label}</strong>
-                <span>{metric.displayBefore} → {metric.displayAfter}</span>
+                <span>{metric.displayBefore} → {metric.displayAfter} ({metric.displayChange})</span>
               </div>
               <div class="comparison-row">
                 <span>Before</span>
@@ -234,11 +246,23 @@ const fullAfter = comparisonSummary[1];
       <div class="table-scroll compact-table">
         <table class="research-table">
           <thead>
-            <tr><th scope="col">Measure</th><th scope="col">Before</th><th scope="col">After</th></tr>
+            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Files added</th><th scope="col">Declarations, start → end</th><th scope="col">Declarations added</th></tr>
+          </thead>
+          <tbody>
+            {testCohortAdditions.map((cohort) => (
+              <tr><th scope="row">{cohort.label}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th><td>{cohort.displayTestFiles}</td><td>{cohort.displayTestFilesAdded}</td><td>{cohort.displayDeclarations}</td><td>{cohort.displayDeclarationsAdded}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div class="table-scroll compact-table">
+        <table class="research-table">
+          <thead>
+            <tr><th scope="col">Measure</th><th scope="col">Before adoption</th><th scope="col">September 3</th><th scope="col">Change during AI cohort</th></tr>
           </thead>
           <tbody>
             {testingMetrics.map((metric) => (
-              <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td></tr>
+              <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td><td>{metric.displayChange}</td></tr>
             ))}
           </tbody>
         </table>
@@ -252,6 +276,43 @@ const fullAfter = comparisonSummary[1];
     </figure>
 
     <div class="article-body quality-reading quality-prose">
+      <section aria-labelledby="historical-baseline-heading">
+        <h2 id="historical-baseline-heading">The 2026 result compared with retrospective pre-AI baselines</h2>
+        <p>
+          Across complete pre-AI cohorts, the median was{" "}
+          {historicalBaseline["Non-dependency merged PRs"].displayBenchmark}{" "}
+          non-dependency merges, {historicalBaseline["Published releases"].displayBenchmark}{" "}
+          releases, {historicalBaseline["Test files added"].displayBenchmark} added
+          test file, and {historicalBaseline["Test declarations added"].displayBenchmark}{" "}
+          added declarations. The observed 2026 values were{" "}
+          {historicalBaseline["Non-dependency merged PRs"].displayActual},{" "}
+          {historicalBaseline["Published releases"].displayActual},{" "}
+          {historicalBaseline["Test files added"].displayActual}, and{" "}
+          {historicalBaseline["Test declarations added"].displayActual}, respectively.
+        </p>
+        <p>
+          Pooling 2022–2025 produces four qualifying within-window introductions
+          across 203 non-dependency merges. Applying that 1.97-per-100 historical
+          rate to the 281 observed 2026 merges gives a 5.54 exposure-scaled
+          expected-value benchmark; the observed count was zero. This is a
+          post-hoc descriptive comparison, not a prospective prediction, a
+          significance test, evidence that AI prevented 5.54 defects, or a causal
+          estimate.
+        </p>
+        <p>
+          Git activity supplies additional workload context: the 2023–2025 median
+          was {gitBaseline["First-parent commits"].displayBenchmark} first-parent
+          commits and {gitBaseline["Total textual churn"].displayBenchmark}; 2026
+          recorded {gitBaseline["First-parent commits"].displayActual} and{" "}
+          {gitBaseline["Total textual churn"].displayActual}. Churn is highly
+          sensitive to generated files, restructuring, and merge strategy, so it
+          is not used as the defect denominator. The{" "}
+          <a href="/quality/2026/context">supplementary data</a> shows every cohort,
+          historical range, churn category, coverage reference, and comparison
+          with the benchmark.
+        </p>
+      </section>
+
       <section aria-labelledby="sensitivity-heading">
         <h2 id="sensitivity-heading">The broader audit gives the same origin pattern</h2>
         <p>
@@ -309,6 +370,8 @@ const fullAfter = comparisonSummary[1];
           <li>The sample contains fourteen product cases, and one reporter supplied six of the 2026 issue reports.</li>
           <li>External reports omit internal findings, silently abandoned use, and unknown defects.</li>
           <li>Pull requests and releases are unequal units of work and risk; their counts provide context, not a controlled exposure measure.</li>
+          <li>Historical baselines were constructed after the 2026 result was visible and use only three or four observations per measure; their ranges are not prediction intervals.</li>
+          <li>The pooled historical defect-rate benchmark rests on only four introduced reports, while commit and churn counts are strongly workflow-dependent.</li>
           <li>Coverage increased across a codebase reorganized into multiple packages, so the before and after denominators are not identical.</li>
           <li>The hypothesis was formulated retrospectively and the audit was performed by the project maintainer, who uses and benefits from agentic coding tools.</li>
           <li>Zero observed post-adoption defect introductions is not proof that no such defect exists.</li>

--- a/site/src/pages/quality/2026/methodology.astro
+++ b/site/src/pages/quality/2026/methodology.astro
@@ -45,10 +45,20 @@ import { auditEvidence } from "../../../data/quality-2026";
     <table class="research-table">
       <thead><tr><th scope="col">Cohort</th><th scope="col">Start, inclusive</th><th scope="col">End, exclusive</th></tr></thead>
       <tbody>
+        <tr><th scope="row">2022 historical comparison</th><td>March 10, 2022 16:38:20 UTC</td><td>September 4, 2022 00:00 UTC</td></tr>
+        <tr><th scope="row">2023 historical comparison</th><td>March 10, 2023 16:38:20 UTC</td><td>September 4, 2023 00:00 UTC</td></tr>
+        <tr><th scope="row">2024 historical comparison</th><td>March 10, 2024 16:38:20 UTC</td><td>September 4, 2024 00:00 UTC</td></tr>
         <tr><th scope="row">2025 matched comparison</th><td>March 10, 2025 16:38:20 UTC</td><td>September 4, 2025 00:00 UTC</td></tr>
         <tr><th scope="row">2026 post-adoption</th><td>March 10, 2026 16:38:20 UTC</td><td>September 4, 2026 00:00 UTC</td></tr>
       </tbody>
     </table>
+    <p>
+      The repository’s reachable history begins April 8, 2022. That cohort can
+      contribute complete GitHub report, pull-request, and npm release counts,
+      but cannot support a March-to-September repository snapshot delta. Its
+      partial Git activity is shown descriptively and excluded from test-growth,
+      coverage-change, commit, and churn baselines.
+    </p>
     <p>
       A supplementary screen covers January 1 through September 3 in both years.
       It preserves all records collected in the original audit and tests whether
@@ -105,6 +115,46 @@ import { auditEvidence } from "../../../data/quality-2026";
       denominator. npm downloads and GitHub stars appear only as exposure context.
     </p>
 
+    <h2>Commit and churn measurement</h2>
+    <p>
+      Commit activity uses committer timestamps and the same start-inclusive,
+      end-exclusive UTC boundaries. The headline count includes only first-parent
+      commits reachable from <code>main</code>. Each is diffed against its first
+      parent with rename detection; a merge therefore contributes the net change
+      it introduced to the mainline once. Topic-branch commits are not counted
+      separately. The analysis ref is the immutable September 3 observation commit,
+      so later merges cannot alter a historical cohort.
+    </p>
+    <p>
+      Textual additions and deletions come from Git numstat output. Churn is their
+      sum. A path changed in multiple commits contributes multiple file-touch
+      occurrences. Binary touches are counted separately and omitted from line
+      totals. Each path enters exactly one category, in priority order: lockfiles
+      and generated artifacts; tests; documentation, changesets, and site content;
+      then source/other. This is a deterministic path classification, not a semantic
+      judgment about the value or difficulty of each line.
+    </p>
+
+    <h2>Retrospective historical baselines</h2>
+    <p>
+      The historical-baseline comparison was constructed after the 2026 outcomes
+      were known. For ordinary measures it reports the median and minimum–maximum
+      range of every complete comparable pre-AI cohort. The range describes the
+      small observed sample; it is not a confidence or prediction interval. The
+      response-time figure is a median of cohort medians because individual
+      historical report intervals are not all stored in the manifest.
+    </p>
+    <p>
+      The introduced-defect benchmark pools qualifying within-window
+      introductions and non-dependency merged pull requests across 2022–2025, then
+      applies that rate to the observed 2026 PR count. It is an exposure-scaled
+      expected-value benchmark, not a predicted defect count, a significance test,
+      or a causal counterfactual. Coverage has only two complete historical deltas,
+      so their midpoint is labeled as reference context rather than a forecast.
+      Commit and churn medians are also descriptive workload context and do not
+      replace the audit’s declared PR exposure denominator.
+    </p>
+
     <h2>Defect-origin classification</h2>
     <ol>
       <li><strong>Same-year regression:</strong> supported behavior demonstrably worked before a specific change in the report year and failed afterward.</li>
@@ -159,8 +209,10 @@ import { auditEvidence } from "../../../data/quality-2026";
       candidate dispositions, all fourteen case histories, the process incident,
       activity measurements, source URLs, and feature chronology. The repository’s
       offline verifier checks window membership, totals, deduplication, source
-      completeness, maturity, and pull-request author sums without depending on a
-      live search result.
+      completeness, maturity, pull-request author sums, historical-baseline inputs,
+      and checked-in churn totals without depending on a live search result. The
+      churn snapshot command can regenerate the Git-derived activity table from
+      local history.
     </p>
     <details>
       <summary>Recorded source queries and commands</summary>
@@ -176,6 +228,9 @@ import { auditEvidence } from "../../../data/quality-2026";
       <li>Fourteen defects are a small sample, and one reporter supplied six of the 2026 issue reports.</li>
       <li>GitHub authorship records provenance, not sole responsibility. Agent-authored work still passed human specification, review, integration, and release decisions.</li>
       <li>Pull requests, releases, tests, coverage, downloads, and stars measure different dimensions and cannot be combined into a universal quality score.</li>
+      <li>The retrospective baselines were selected after the 2026 results were visible, use only three or four observations per measure, and are not causal estimates.</li>
+      <li>The pooled historical defect-rate numerator contains only four events; its exposure-scaled benchmark is highly unstable.</li>
+      <li>Commit counts and churn depend on merge strategy, generated files, formatting, and repository reorganization; lines changed are not engineering effort.</li>
       <li>The package reorganization changed the coverage denominator, so the public percentages do not describe an identical set of files.</li>
       <li>The absence of an observed post-adoption defect introduction does not prove that none exists.</li>
     </ul>


### PR DESCRIPTION
## Summary

- add matched March 10–September 3 cohorts for 2022, 2023, and 2024 to the quality audit
- report historical delivery, test growth, Coveralls coverage, external defect counts, and defect-introduction chronology
- add reproducible first-parent commit and categorized textual-churn measurements pinned to the audit observation commit
- compare the 2026 AI cohort with metric-specific pre-AI medians, historical ranges, and an exposure-scaled introduced-defect benchmark
- document why the post-hoc comparisons are descriptive rather than prospective predictions or causal estimates

<details>
<summary>Original Prompt</summary>

> The bug audit looks at test counts at the start and end of the AI cohort. But it doesn’t show how many tests were added in the first cohort.
>
> What were the deltas in the first cohort
>
> There wasn’t much activity in that timeframe. Let’s add cohorts for the same timeframe in 2022, 2023, and 2024. Use subagents so the context window doesn’t get too large.
>
> Perform the other analyses as well: test coverage, bugs reported and when they were introduced, etc.
>
> Does the report also track commits and lines changed? Now that we have multiple pre-AI cohorts can we use those to make predictions for the AI cohort, and compare those predictions with actual?
>
> Implement this plan.

</details>

## Agent-created PR notes

## Skipped manual acceptance tests

Keeping these in case they prove valuable later but I'm not going to run them. 

- Open the main quality article and confirm the automated-verification table shows start, end, and added test-file/declaration counts for every cohort from 2022 through the 2026 AI cohort.
- Open the supplementary-data page and confirm delivery, coverage, external-defect, first-parent commit, added/deleted-line, total-churn, and categorized-churn tables render for the available cohorts.
- Confirm the retrospective comparison shows 56.5 non-dependency PRs, 13 releases, one added test file, ten added test declarations, and 5.54 exposure-scaled introduced reports as the displayed 2026 benchmarks.
- Confirm the 2022 repository-derived deltas are marked not estimable or partial history, and the 2024 churn note explains the large add/remove Yarn artifact without classifying it as product-source churn.
- Run the audit test, verifier, churn snapshot, and site build commands and confirm the original 2025/2026 defect results remain unchanged while the historical and Git-derived checks pass.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: Existing repository guidance already requires immutable audit identifiers, checked-in evidence, and offline consistency checks; the additional cohort-specific calculation rules are encoded in the audit scripts, manifest, and methodology.

## Tasks

- derived and published matched historical test, coverage, delivery, and defect cohorts
- added a pinned first-parent Git churn counter with deterministic path categories and rename/binary handling
- added retrospective historical-baseline and actual-versus-benchmark calculations with metric-specific eligibility
- extended the audit tests and offline verifier to protect boundaries, cohort denominators, churn totals, and forecast arithmetic
- updated the main article, supplementary data, methods, and downloadable evidence manifest

## Verification

- `npm --prefix site run test:audit` — 17 tests passed
- `npm --prefix site run verify:audit` — passed
- `npm --prefix site run snapshot:churn -- 77f0bc6fd2c3bc935d2eb2da80190369d91f7084` — reproduced the checked-in cohort totals
- `npm --prefix site run build` — 95 pages built
- `git diff origin/main...HEAD --check` — passed

Repository-wide `yarn lint` was not available because this worktree does not have a `yarn` executable or installed root ESLint binary. The site-specific build and targeted audit verification completed successfully.
