### PR TITLE
Clarify five-year quality report comparisons

### DIFF
--- a/site/scripts/quality-audit.test.mjs
+++ b/site/scripts/quality-audit.test.mjs
@@ -152,6 +152,7 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
     {
       comparison2022: {
         status: comparison2022.status,
+        firstReachableCommit: comparison2022.firstReachableCommit,
         endTestFiles: comparison2022.end.testFiles,
         endTestDeclarations: comparison2022.end.testDeclarations,
       },
@@ -175,10 +176,10 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
         testFiles: endOfObservation.testFiles - preAdoption.testFiles,
         testDeclarations:
           endOfObservation.testDeclarations - preAdoption.testDeclarations,
-        lineCoveragePercentagePoints: Number(
+        branchCoveragePercentagePoints: Number(
           (
-            endOfObservation.lineCoveragePercent -
-            preAdoption.lineCoveragePercent
+            endOfObservation.branchCoveragePercent -
+            preAdoption.branchCoveragePercent
           ).toFixed(3),
         ),
       },
@@ -186,6 +187,7 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
     {
       comparison2022: {
         status: "not_estimable",
+        firstReachableCommit: "238c74baa4748932dc5580cc0a18016b9442d21e",
         endTestFiles: 21,
         endTestDeclarations: 94,
       },
@@ -195,24 +197,24 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
       aiCohort: {
         testFiles: 36,
         testDeclarations: 634,
-        lineCoveragePercentagePoints: 8.846,
+        branchCoveragePercentagePoints: 0.071,
       },
     },
   );
   assert.deepEqual(
     {
-      2022: historicCoverage["2022"].coverage.end.coveredPercent,
-      2023: historicCoverage["2023"].coverage.end.coveredPercent,
-      2024: historicCoverage["2024"].coverage.end.coveredPercent,
-      2025: supplementalCoverage["2025"].percent,
-      2026: endOfObservation.lineCoveragePercent,
+      2022: historicCoverage["2022"].coverage.end.branchCoveragePercent,
+      2023: historicCoverage["2023"].coverage.end.branchCoveragePercent,
+      2024: historicCoverage["2024"].coverage.end.branchCoveragePercent,
+      2025: supplementalCoverage["2025"].branchCoveragePercent,
+      2026: endOfObservation.branchCoveragePercent,
     },
     {
-      2022: 92.0652173913044,
-      2023: 85.17208105500161,
-      2024: 82.59851736246586,
-      2025: 84.26,
-      2026: 91.73,
+      2022: 95.51282051282051,
+      2023: 91.74560216508796,
+      2024: 89.85637342908439,
+      2025: 90.13107170393215,
+      2026: 89.41451990632319,
     },
   );
 });
@@ -231,8 +233,8 @@ test("historic delivery and coverage retain matched-window limitations", () => {
         releases: cohorts["2023"].publishedReleases,
         coverageChange: Number(
           (
-            cohorts["2023"].coverage.end.coveredPercent -
-            cohorts["2023"].coverage.start.coveredPercent
+            cohorts["2023"].coverage.end.branchCoveragePercent -
+            cohorts["2023"].coverage.start.branchCoveragePercent
           ).toFixed(3),
         ),
       },
@@ -241,8 +243,8 @@ test("historic delivery and coverage retain matched-window limitations", () => {
         releases: cohorts["2024"].publishedReleases,
         coverageChange: Number(
           (
-            cohorts["2024"].coverage.end.coveredPercent -
-            cohorts["2024"].coverage.start.coveredPercent
+            cohorts["2024"].coverage.end.branchCoveragePercent -
+            cohorts["2024"].coverage.start.branchCoveragePercent
           ).toFixed(3),
         ),
       },
@@ -256,12 +258,12 @@ test("historic delivery and coverage retain matched-window limitations", () => {
       2023: {
         nonDependencyMerges: 50,
         releases: 19,
-        coverageChange: -2.294,
+        coverageChange: -2.686,
       },
       2024: {
         nonDependencyMerges: 75,
         releases: 24,
-        coverageChange: -3.629,
+        coverageChange: -0.827,
       },
     },
   );
@@ -407,19 +409,19 @@ test("coverage reference stays a two-cohort descriptive midpoint", () => {
   const cohorts = manifest.activity.historicCohorts;
   const changes = ["2023", "2024"].map(
     (year) =>
-      cohorts[year].coverage.end.coveredPercent -
-      cohorts[year].coverage.start.coveredPercent,
+      cohorts[year].coverage.end.branchCoveragePercent -
+      cohorts[year].coverage.start.branchCoveragePercent,
   );
-  assert.equal(Number(median(changes).toFixed(3)), -2.961);
+  assert.equal(Number(median(changes).toFixed(3)), -1.756);
   assert.equal(
     Number(
       (
-        manifest.activity.snapshots.endOfObservation.lineCoveragePercent -
-        manifest.activity.snapshots.preAdoption.lineCoveragePercent -
+        manifest.activity.snapshots.endOfObservation.branchCoveragePercent -
+        manifest.activity.snapshots.preAdoption.branchCoveragePercent -
         median(changes)
       ).toFixed(3),
     ),
-    11.807,
+    1.827,
   );
 });
 

--- a/site/scripts/quality-audit.test.mjs
+++ b/site/scripts/quality-audit.test.mjs
@@ -142,10 +142,12 @@ test("checked-in primary cohorts reproduce the article results", () => {
   ]);
 });
 
-test("automated verification snapshots report the historical cohort additions", () => {
+test("automated verification snapshots retain all five cohort endpoints", () => {
   const { comparison2022, comparison2023, comparison2024, comparison2025 } =
     manifest.activity.snapshots;
   const { preAdoption, endOfObservation } = manifest.activity.snapshots;
+  const historicCoverage = manifest.activity.historicCohorts;
+  const supplementalCoverage = manifest.activity.supplementalFullWindow.coverage;
   assert.deepEqual(
     {
       comparison2022: {
@@ -195,6 +197,22 @@ test("automated verification snapshots report the historical cohort additions", 
         testDeclarations: 634,
         lineCoveragePercentagePoints: 8.846,
       },
+    },
+  );
+  assert.deepEqual(
+    {
+      2022: historicCoverage["2022"].coverage.end.coveredPercent,
+      2023: historicCoverage["2023"].coverage.end.coveredPercent,
+      2024: historicCoverage["2024"].coverage.end.coveredPercent,
+      2025: supplementalCoverage["2025"].percent,
+      2026: endOfObservation.lineCoveragePercent,
+    },
+    {
+      2022: 92.0652173913044,
+      2023: 85.17208105500161,
+      2024: 82.59851736246586,
+      2025: 84.26,
+      2026: 91.73,
     },
   );
 });

--- a/site/scripts/quality-audit.test.mjs
+++ b/site/scripts/quality-audit.test.mjs
@@ -171,6 +171,10 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
         testDeclarations:
           comparison2025.end.testDeclarations -
           comparison2025.start.testDeclarations,
+        branchCoveragePercent:
+          comparison2025.start.branchCoverage.branchCoveragePercent,
+        coverageKind: comparison2025.start.branchCoverage.kind,
+        failedSuites: comparison2025.start.branchCoverage.testResult.failedSuites,
       },
       aiCohort: {
         testFiles: endOfObservation.testFiles - preAdoption.testFiles,
@@ -193,7 +197,13 @@ test("automated verification snapshots retain all five cohort endpoints", () => 
       },
       comparison2023: { testFiles: 0, testDeclarations: 10 },
       comparison2024: { testFiles: 6, testDeclarations: 48 },
-      comparison2025: { testFiles: 1, testDeclarations: 6 },
+      comparison2025: {
+        testFiles: 1,
+        testDeclarations: 6,
+        branchCoveragePercent: 89.72,
+        coverageKind: "local-recomputation",
+        failedSuites: 1,
+      },
       aiCohort: {
         testFiles: 36,
         testDeclarations: 634,

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -249,6 +249,7 @@ const formatCoverage = (percent: number) => `${percent.toFixed(3)}%`;
 type BranchCoverageSnapshot = {
   branchCoveragePercent: number;
   source: string;
+  sourceLabel?: string;
 };
 
 const verificationCohort = (
@@ -321,7 +322,12 @@ export const verificationCohorts = [
     2025,
     comparison2025Snapshots.start,
     comparison2025Snapshots.end,
-    undefined,
+    {
+      branchCoveragePercent:
+        comparison2025Snapshots.start.branchCoverage.branchCoveragePercent,
+      source: comparison2025Snapshots.start.branchCoverage.source,
+      sourceLabel: "local recomputation",
+    },
     {
       branchCoveragePercent:
         evidence.activity.supplementalFullWindow.coverage["2025"]
@@ -330,7 +336,7 @@ export const verificationCohorts = [
         evidence.activity.supplementalFullWindow.coverage["2025"]
           .branchCoverageSource,
     },
-    "No Coveralls build is available at the March start commit.",
+    "The 89.720% start value was locally recomputed at the exact March commit with Node v22.2.0; the unchanged historical suite had one failing response-builder assertion. It is not a Coveralls build.",
   ),
   verificationCohort(
     2026,

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -243,80 +243,80 @@ const comparison2022Snapshots = snapshots.comparison2022;
 const comparison2023Snapshots = snapshots.comparison2023;
 const comparison2024Snapshots = snapshots.comparison2024;
 const comparison2025Snapshots = snapshots.comparison2025;
-
-export const testingMetrics = [
-  {
-    label: "Conventional test files",
-    before: snapshots.preAdoption.testFiles,
-    after: snapshots.endOfObservation.testFiles,
-    displayBefore: String(snapshots.preAdoption.testFiles),
-    displayAfter: String(snapshots.endOfObservation.testFiles),
-    displayChange: displaySignedChange(
-      snapshots.endOfObservation.testFiles - snapshots.preAdoption.testFiles,
-    ),
-  },
-  {
-    label: "Explicit test declarations",
-    before: snapshots.preAdoption.testDeclarations,
-    after: snapshots.endOfObservation.testDeclarations,
-    displayBefore: String(snapshots.preAdoption.testDeclarations),
-    displayAfter: String(snapshots.endOfObservation.testDeclarations),
-    displayChange: displaySignedChange(
-      snapshots.endOfObservation.testDeclarations -
-        snapshots.preAdoption.testDeclarations,
-    ),
-  },
-  {
-    label: "Reported line coverage",
-    before: snapshots.preAdoption.lineCoveragePercent,
-    after: snapshots.endOfObservation.lineCoveragePercent,
-    displayBefore: `${snapshots.preAdoption.lineCoveragePercent}%`,
-    displayAfter: `${snapshots.endOfObservation.lineCoveragePercent}%`,
-    displayChange: displaySignedChange(
-      Number(
-        (
-          snapshots.endOfObservation.lineCoveragePercent -
-          snapshots.preAdoption.lineCoveragePercent
-        ).toFixed(3),
-      ),
-      " percentage points",
-    ),
-  },
-] as const;
-
-export const testCohortAdditions = [
-  {
-    label: "2022 comparison",
-    note: comparison2022Snapshots.reason,
-    displayTestFiles: `Not available → ${comparison2022Snapshots.end.testFiles}`,
-    displayTestFilesAdded: "Not estimable",
-    displayDeclarations: `Not available → ${comparison2022Snapshots.end.testDeclarations}`,
-    displayDeclarationsAdded: "Not estimable",
-  },
-  cohortAddition(
-    "2023 comparison",
-    comparison2023Snapshots.start,
-    comparison2023Snapshots.end,
-  ),
-  cohortAddition(
-    "2024 comparison",
-    comparison2024Snapshots.start,
-    comparison2024Snapshots.end,
-  ),
-  cohortAddition(
-    "2025 comparison",
-    comparison2025Snapshots.start,
-    comparison2025Snapshots.end,
-  ),
-  cohortAddition(
-    "2026 AI cohort",
-    snapshots.preAdoption,
-    snapshots.endOfObservation,
-  ),
-];
-
 const historicCohorts = evidence.activity.historicCohorts;
 const formatCoverage = (percent: number) => `${percent.toFixed(3)}%`;
+
+type VerificationSnapshot = TestCountSnapshot & {
+  lineCoveragePercent: number;
+  coverageSource: string;
+};
+
+const verificationCohort = (
+  year: number,
+  start: TestCountSnapshot | undefined,
+  end: VerificationSnapshot,
+  note?: string,
+) => ({
+  year,
+  testFiles: start
+    ? `${start.testFiles} → ${end.testFiles}`
+    : `Not available → ${end.testFiles}`,
+  testDeclarations: start
+    ? `${start.testDeclarations} → ${end.testDeclarations}`
+    : `Not available → ${end.testDeclarations}`,
+  lineCoveragePercent: end.lineCoveragePercent,
+  coverageSource: end.coverageSource,
+  note,
+});
+
+export const verificationCohorts = [
+  verificationCohort(
+    2022,
+    undefined,
+    {
+      ...comparison2022Snapshots.end,
+      lineCoveragePercent: historicCohorts["2022"].coverage.end.coveredPercent,
+      coverageSource: historicCohorts["2022"].coverage.end.source,
+    },
+    comparison2022Snapshots.reason,
+  ),
+  verificationCohort(
+    2023,
+    comparison2023Snapshots.start,
+    {
+      ...comparison2023Snapshots.end,
+      lineCoveragePercent: historicCohorts["2023"].coverage.end.coveredPercent,
+      coverageSource: historicCohorts["2023"].coverage.end.source,
+    },
+  ),
+  verificationCohort(
+    2024,
+    comparison2024Snapshots.start,
+    {
+      ...comparison2024Snapshots.end,
+      lineCoveragePercent: historicCohorts["2024"].coverage.end.coveredPercent,
+      coverageSource: historicCohorts["2024"].coverage.end.source,
+    },
+  ),
+  verificationCohort(
+    2025,
+    comparison2025Snapshots.start,
+    {
+      ...comparison2025Snapshots.end,
+      lineCoveragePercent: evidence.activity.supplementalFullWindow.coverage["2025"].percent,
+      coverageSource: evidence.activity.supplementalFullWindow.coverage["2025"].source,
+    },
+  ),
+  verificationCohort(
+    2026,
+    snapshots.preAdoption,
+    {
+      ...snapshots.endOfObservation,
+      lineCoveragePercent: snapshots.endOfObservation.lineCoveragePercent,
+      coverageSource: snapshots.endOfObservation.coverageSource,
+    },
+  ),
+];
 
 export const historicDeliveryAndCoverage = [2022, 2023, 2024].map((year) => {
   const cohort = historicCohorts[String(year) as "2022" | "2023" | "2024"];
@@ -342,6 +342,34 @@ export const historicDeliveryAndCoverage = [2022, 2023, 2024].map((year) => {
 });
 
 const historicDefectCohorts = evidence.activity.historicDefectCohorts;
+
+export const matchedWindowCohorts = [2022, 2023, 2024].map((year) => {
+  const cohort = historicCohorts[String(year) as "2022" | "2023" | "2024"];
+  const defects =
+    historicDefectCohorts[String(year) as "2022" | "2023" | "2024"];
+  return {
+    year,
+    totalReports: defects.qualifyingExternalProductDefects,
+    introduced: defects.introducedWithinWindow,
+    medianResponseDays: defects.medianResponseDays,
+    allMergedPullRequests: cohort.mergedPullRequests,
+    nonDependencyMerges: cohort.nonDependencyMergedPullRequests,
+    releases: cohort.publishedReleases,
+  };
+}).concat(
+  primaryComparisonSummary.map((cohort) => ({
+    year: cohort.year,
+    totalReports: cohort.totalReports,
+    introduced: cohort.introduced,
+    medianResponseDays: cohort.medianResponseDays,
+    allMergedPullRequests:
+      evidence.activity.primaryWindow.mergedPullRequests[
+        String(cohort.year) as "2025" | "2026"
+      ],
+    nonDependencyMerges: cohort.nonDependencyMerges,
+    releases: cohort.releases,
+  })),
+);
 
 export const historicDefectSummaries = [2022, 2023, 2024].map((year) => {
   const cohort =

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -249,7 +249,7 @@ const formatCoverage = (percent: number) => `${percent.toFixed(3)}%`;
 type BranchCoverageSnapshot = {
   branchCoveragePercent: number;
   source: string;
-  sourceLabel?: string;
+  footnoteMarker?: string;
 };
 
 const verificationCohort = (
@@ -326,7 +326,7 @@ export const verificationCohorts = [
       branchCoveragePercent:
         comparison2025Snapshots.start.branchCoverage.branchCoveragePercent,
       source: comparison2025Snapshots.start.branchCoverage.source,
-      sourceLabel: "local recomputation",
+      footnoteMarker: "*",
     },
     {
       branchCoveragePercent:
@@ -336,7 +336,6 @@ export const verificationCohorts = [
         evidence.activity.supplementalFullWindow.coverage["2025"]
           .branchCoverageSource,
     },
-    "The 89.720% start value was locally recomputed at the exact March commit with Node v22.2.0; the unchanged historical suite had one failing response-builder assertion. It is not a Coveralls build.",
   ),
   verificationCohort(
     2026,

--- a/site/src/data/quality-2026.ts
+++ b/site/src/data/quality-2026.ts
@@ -246,16 +246,19 @@ const comparison2025Snapshots = snapshots.comparison2025;
 const historicCohorts = evidence.activity.historicCohorts;
 const formatCoverage = (percent: number) => `${percent.toFixed(3)}%`;
 
-type VerificationSnapshot = TestCountSnapshot & {
-  lineCoveragePercent: number;
-  coverageSource: string;
+type BranchCoverageSnapshot = {
+  branchCoveragePercent: number;
+  source: string;
 };
 
 const verificationCohort = (
   year: number,
   start: TestCountSnapshot | undefined,
-  end: VerificationSnapshot,
+  end: TestCountSnapshot,
+  branchCoverageStart: BranchCoverageSnapshot | undefined,
+  branchCoverageEnd: BranchCoverageSnapshot,
   note?: string,
+  firstReachableCommit?: string,
 ) => ({
   year,
   testFiles: start
@@ -264,56 +267,82 @@ const verificationCohort = (
   testDeclarations: start
     ? `${start.testDeclarations} → ${end.testDeclarations}`
     : `Not available → ${end.testDeclarations}`,
-  lineCoveragePercent: end.lineCoveragePercent,
-  coverageSource: end.coverageSource,
+  branchCoverageStart,
+  branchCoverageEnd,
   note,
+  firstReachableCommit,
 });
 
 export const verificationCohorts = [
   verificationCohort(
     2022,
     undefined,
+    comparison2022Snapshots.end,
+    undefined,
     {
-      ...comparison2022Snapshots.end,
-      lineCoveragePercent: historicCohorts["2022"].coverage.end.coveredPercent,
-      coverageSource: historicCohorts["2022"].coverage.end.source,
+      branchCoveragePercent:
+        historicCohorts["2022"].coverage.end.branchCoveragePercent,
+      source: historicCohorts["2022"].coverage.end.source,
     },
-    comparison2022Snapshots.reason,
+    "The March start snapshot is unavailable because main-reachable history begins after the boundary.",
+    comparison2022Snapshots.firstReachableCommit,
   ),
   verificationCohort(
     2023,
     comparison2023Snapshots.start,
+    comparison2023Snapshots.end,
     {
-      ...comparison2023Snapshots.end,
-      lineCoveragePercent: historicCohorts["2023"].coverage.end.coveredPercent,
-      coverageSource: historicCohorts["2023"].coverage.end.source,
+      branchCoveragePercent:
+        historicCohorts["2023"].coverage.start.branchCoveragePercent,
+      source: historicCohorts["2023"].coverage.start.source,
+    },
+    {
+      branchCoveragePercent:
+        historicCohorts["2023"].coverage.end.branchCoveragePercent,
+      source: historicCohorts["2023"].coverage.end.source,
     },
   ),
   verificationCohort(
     2024,
     comparison2024Snapshots.start,
+    comparison2024Snapshots.end,
     {
-      ...comparison2024Snapshots.end,
-      lineCoveragePercent: historicCohorts["2024"].coverage.end.coveredPercent,
-      coverageSource: historicCohorts["2024"].coverage.end.source,
+      branchCoveragePercent:
+        historicCohorts["2024"].coverage.start.branchCoveragePercent,
+      source: historicCohorts["2024"].coverage.start.source,
+    },
+    {
+      branchCoveragePercent:
+        historicCohorts["2024"].coverage.end.branchCoveragePercent,
+      source: historicCohorts["2024"].coverage.end.source,
     },
   ),
   verificationCohort(
     2025,
     comparison2025Snapshots.start,
+    comparison2025Snapshots.end,
+    undefined,
     {
-      ...comparison2025Snapshots.end,
-      lineCoveragePercent: evidence.activity.supplementalFullWindow.coverage["2025"].percent,
-      coverageSource: evidence.activity.supplementalFullWindow.coverage["2025"].source,
+      branchCoveragePercent:
+        evidence.activity.supplementalFullWindow.coverage["2025"]
+          .branchCoveragePercent,
+      source:
+        evidence.activity.supplementalFullWindow.coverage["2025"]
+          .branchCoverageSource,
     },
+    "No Coveralls build is available at the March start commit.",
   ),
   verificationCohort(
     2026,
     snapshots.preAdoption,
+    snapshots.endOfObservation,
     {
-      ...snapshots.endOfObservation,
-      lineCoveragePercent: snapshots.endOfObservation.lineCoveragePercent,
-      coverageSource: snapshots.endOfObservation.coverageSource,
+      branchCoveragePercent: snapshots.preAdoption.branchCoveragePercent,
+      source: snapshots.preAdoption.coverageSource,
+    },
+    {
+      branchCoveragePercent: snapshots.endOfObservation.branchCoveragePercent,
+      source: snapshots.endOfObservation.branchCoverageSource,
     },
   ),
 ];
@@ -325,18 +354,21 @@ export const historicDeliveryAndCoverage = [2022, 2023, 2024].map((year) => {
     return {
       year,
       ...cohort,
-      coverageDisplay: `Not available → ${formatCoverage(coverage.end.coveredPercent)}`,
+      coverageDisplay: `Not available → ${formatCoverage(coverage.end.branchCoveragePercent)}`,
       coverageChange: "Not estimable",
       coverageNote: coverage.reason,
     };
   }
   const change = Number(
-    (coverage.end.coveredPercent - coverage.start.coveredPercent).toFixed(3),
+    (
+      coverage.end.branchCoveragePercent -
+      coverage.start.branchCoveragePercent
+    ).toFixed(3),
   );
   return {
     year,
     ...cohort,
-    coverageDisplay: `${formatCoverage(coverage.start.coveredPercent)} → ${formatCoverage(coverage.end.coveredPercent)}`,
+    coverageDisplay: `${formatCoverage(coverage.start.branchCoveragePercent)} → ${formatCoverage(coverage.end.branchCoveragePercent)}`,
     coverageChange: `${displaySignedChange(change)} percentage points`,
   };
 });
@@ -546,12 +578,12 @@ export const retrospectiveBaselineRows = [
 
 const completeHistoricalCoverageChanges = ["2023", "2024"].map((year) => {
   const coverage = historicCohorts[year as "2023" | "2024"].coverage;
-  return coverage.end.coveredPercent - coverage.start.coveredPercent;
+  return coverage.end.branchCoveragePercent - coverage.start.branchCoveragePercent;
 });
 const coverageReferenceMidpoint = median(completeHistoricalCoverageChanges);
 const actualCoverageChange =
-  snapshots.endOfObservation.lineCoveragePercent -
-  snapshots.preAdoption.lineCoveragePercent;
+  snapshots.endOfObservation.branchCoveragePercent -
+  snapshots.preAdoption.branchCoveragePercent;
 export const coverageReference = {
   historicalYears: "2023–2024",
   midpoint: coverageReferenceMidpoint,

--- a/site/src/data/quality-audit-evidence.json
+++ b/site/src/data/quality-audit-evidence.json
@@ -899,6 +899,7 @@
           "end": {
             "commit": "13c246c1795e66cffc1a0e022b407660ec384b02",
             "coveredPercent": 92.0652173913044,
+            "branchCoveragePercent": 95.51282051282051,
             "source": "https://coveralls.io/builds/52174439"
           }
         }
@@ -912,11 +913,13 @@
           "start": {
             "commit": "06c354e0f30d52776006929f7c7e657520adf330",
             "coveredPercent": 87.4656188605108,
+            "branchCoveragePercent": 94.43155452436194,
             "source": "https://coveralls.io/builds/57532255"
           },
           "end": {
             "commit": "061d88e7ba072dbfa931ec306b4e6ae94f32b155",
             "coveredPercent": 85.17208105500161,
+            "branchCoveragePercent": 91.74560216508796,
             "source": "https://coveralls.io/builds/62400840"
           }
         }
@@ -930,11 +933,13 @@
           "start": {
             "commit": "f17e758dbf87d58fb09e8910190d590c216609e5",
             "coveredPercent": 86.227261989133,
+            "branchCoveragePercent": 90.6832298136646,
             "source": "https://coveralls.io/builds/66186038"
           },
           "end": {
             "commit": "7eaccb20ae8f26e4b767dfb9f4f9e92b09623744",
             "coveredPercent": 82.59851736246586,
+            "branchCoveragePercent": 89.85637342908439,
             "source": "https://coveralls.io/builds/69559350"
           }
         }
@@ -1112,6 +1117,7 @@
       "comparison2022": {
         "status": "not_estimable",
         "reason": "The first main-reachable commit is 238c74baa4748932dc5580cc0a18016b9442d21e on April 8, 2022, after the March 10 start boundary.",
+        "firstReachableCommit": "238c74baa4748932dc5580cc0a18016b9442d21e",
         "end": {
           "commit": "13c246c1795e66cffc1a0e022b407660ec384b02",
           "observedAt": "2022-09-04T00:00:00Z",
@@ -1167,6 +1173,7 @@
         "testFiles": 36,
         "testDeclarations": 270,
         "lineCoveragePercent": 82.884,
+        "branchCoveragePercent": 89.34368383909668,
         "coverageSource": "https://coveralls.io/builds/78168279"
       },
       "endOfObservation": {
@@ -1175,6 +1182,8 @@
         "testFiles": 72,
         "testDeclarations": 904,
         "lineCoveragePercent": 91.73,
+        "branchCoveragePercent": 89.41451990632319,
+        "branchCoverageSource": "https://coveralls.io/builds/81535061",
         "coverageSource": "https://coveralls.io/github/counterfact/api-simulator/commit/77f0bc6fd2c3bc935d2eb2da80190369d91f7084"
       }
     },
@@ -1204,10 +1213,14 @@
       "coverage": {
         "2025": {
           "percent": 84.26,
+          "branchCoveragePercent": 90.13107170393215,
+          "branchCoverageSource": "https://coveralls.io/builds/75373758",
           "source": "https://coveralls.io/builds/76781774"
         },
         "2026": {
           "percent": 91.73,
+          "branchCoveragePercent": 89.41451990632319,
+          "branchCoverageSource": "https://coveralls.io/builds/81535061",
           "source": "https://coveralls.io/github/counterfact/api-simulator/commit/77f0bc6fd2c3bc935d2eb2da80190369d91f7084",
           "check": "https://github.com/counterfact/api-simulator/actions/runs/33722238152/job/100543591129",
           "observedAt": "2026-09-03T18:00:00Z"

--- a/site/src/data/quality-audit-evidence.json
+++ b/site/src/data/quality-audit-evidence.json
@@ -1158,7 +1158,26 @@
           "commit": "d8eeb73d6a16f266719384f7c6ef5b3a1f556e4b",
           "observedAt": "2025-03-10T16:38:20Z",
           "testFiles": 34,
-          "testDeclarations": 233
+          "testDeclarations": 233,
+          "branchCoverage": {
+            "kind": "local-recomputation",
+            "branchCoveragePercent": 89.72,
+            "source": "https://github.com/counterfact/api-simulator/commit/d8eeb73d6a16f266719384f7c6ef5b3a1f556e4b",
+            "observedAt": "2026-09-07",
+            "nodeVersion": "v22.2.0",
+            "yarnVersion": "1.22.22",
+            "command": "yarn test --coverage",
+            "testResult": {
+              "passedSuites": 32,
+              "failedSuites": 1,
+              "passedTests": 262,
+              "failedTests": 1,
+              "skippedTests": 2,
+              "todoTests": 1,
+              "failure": "test/server/response-builder.test.ts: a response builder > has shortcuts for json, text, and html"
+            },
+            "note": "The unchanged historical suite did not pass: one response-builder assertion failed. This is a local coverage recomputation, not a Coveralls build."
+          }
         },
         "end": {
           "commit": "939d149f753edcc0c2de10db1afb60c335840231",

--- a/site/src/pages/quality/2026/cases/index.astro
+++ b/site/src/pages/quality/2026/cases/index.astro
@@ -30,8 +30,10 @@ const incident = processIncidents[0];
         Fourteen reports met the product-defect rule: four in the full 2025
         screen and ten in 2026. Each case traces the reported behavior backward
         through source history and forward to the first release containing the
-        accepted correction. Primary-window membership is shown separately from
-        defect origin.
+        accepted correction. This appendix preserves the original two-year case
+        inventory; the article’s matched-window results separately incorporate
+        the 2022–2024 historical cohorts. Primary-window membership is shown
+        separately from defect origin.
       </p>
     </header>
 

--- a/site/src/pages/quality/2026/context.astro
+++ b/site/src/pages/quality/2026/context.astro
@@ -140,12 +140,14 @@ const adoption = auditEvidence.activity.adoption;
     </p>
     <p>
       Public branch coverage moved from 89.344% to 89.415% in 2026. The available
-      earlier pairs are 94.432% to 91.746% (2023) and 90.683% to 89.856% (2024);
-      2022 and 2025 have no Coveralls build at the March start boundary. Their
-      endpoints are 95.513% and 90.131%, respectively. During the 2026 interval
-      the project was reorganized into multiple packages, so the percentages are
-      real results over changing source sets rather than a controlled measurement
-      over identical files.
+      earlier pairs are 94.432% to 91.746% (2023) and 90.683% to 89.856% (2024).
+      The 2025 start commit has no Coveralls build, but a local recomputation at
+      that exact commit measured 89.720% before the public 90.131% endpoint; the
+      unchanged historical suite retained one failing response-builder assertion.
+      The 2022 cohort has no March start observation and ends at 95.513%. During
+      the 2026 interval the project was reorganized into multiple packages, so the
+      percentages are real results over changing source sets rather than a
+      controlled measurement over identical files.
     </p>
 
     <h2>Commit and line-change activity</h2>

--- a/site/src/pages/quality/2026/context.astro
+++ b/site/src/pages/quality/2026/context.astro
@@ -88,7 +88,7 @@ const adoption = auditEvidence.activity.adoption;
     </p>
     <div class="table-scroll">
       <table class="research-table">
-        <thead><tr><th scope="col">Cohort</th><th scope="col">All merged PRs</th><th scope="col">Non-dependency merged PRs</th><th scope="col">Published releases</th><th scope="col">Coveralls line coverage, start → end</th><th scope="col">Coverage change</th></tr></thead>
+        <thead><tr><th scope="col">Cohort</th><th scope="col">All merged PRs</th><th scope="col">Non-dependency merged PRs</th><th scope="col">Published releases</th><th scope="col">Coveralls branch coverage, start → end</th><th scope="col">Coverage change</th></tr></thead>
         <tbody>
           {historicDeliveryAndCoverage.map((cohort) => (
             <tr><th scope="row">{cohort.year}{cohort.coverageNote && <span class="cell-detail">{cohort.coverageNote}</span>}</th><td>{cohort.mergedPullRequests}</td><td>{cohort.nonDependencyMergedPullRequests}</td><td>{cohort.publishedReleases}</td><td>{cohort.coverageDisplay}</td><td>{cohort.coverageChange}</td></tr>
@@ -127,7 +127,7 @@ const adoption = auditEvidence.activity.adoption;
     <p>
       The article’s single <a href="/quality/2026#verification-heading">five-year
       verification table</a> provides the matched test-file, declaration, and
-      endpoint line-coverage observations for 2022–2026. Keeping the data in one
+      branch-coverage start and end observations for 2022–2026. Keeping the data in one
       place avoids treating the 2025–2026 comparison as the only historical frame.
     </p>
     <p>
@@ -139,11 +139,13 @@ const adoption = auditEvidence.activity.adoption;
       available in the repository and both invocations appear under Methods.
     </p>
     <p>
-      Public line coverage was 91.73% at the 2026 endpoint, following endpoint
-      observations of 92.065% (2022), 85.172% (2023), 82.599% (2024), and 84.260%
-      (2025). During the 2026 interval the project was reorganized into multiple
-      packages, so the percentages are real results over changing source sets
-      rather than a controlled measurement over identical files.
+      Public branch coverage moved from 89.344% to 89.415% in 2026. The available
+      earlier pairs are 94.432% to 91.746% (2023) and 90.683% to 89.856% (2024);
+      2022 and 2025 have no Coveralls build at the March start boundary. Their
+      endpoints are 95.513% and 90.131%, respectively. During the 2026 interval
+      the project was reorganized into multiple packages, so the percentages are
+      real results over changing source sets rather than a controlled measurement
+      over identical files.
     </p>
 
     <h2>Commit and line-change activity</h2>

--- a/site/src/pages/quality/2026/context.astro
+++ b/site/src/pages/quality/2026/context.astro
@@ -3,15 +3,13 @@ import QualityLayout from "../../../layouts/QualityLayout.astro";
 import {
   auditEvidence,
   coverageReference,
-  deliveryMetrics,
   featureTimeline,
   gitCohortMetrics,
   gitHistoricalBaselineRows,
   historicDefectSummaries,
   historicDeliveryAndCoverage,
+  matchedWindowCohorts,
   retrospectiveBaselineRows,
-  testCohortAdditions,
-  testingMetrics,
 } from "../../../data/quality-2026";
 
 const supplemental = auditEvidence.activity.supplementalFullWindow;
@@ -37,25 +35,44 @@ const adoption = auditEvidence.activity.adoption;
     </header>
 
     <h2>Matched-window delivery activity</h2>
-    <table class="research-table">
-      <thead><tr><th scope="col">Measure</th><th scope="col">2025 comparison</th><th scope="col">2026 post-adoption</th></tr></thead>
+    <div class="table-scroll">
+      <table class="research-table">
+      <thead><tr><th scope="col">Measure</th>{matchedWindowCohorts.map((cohort) => <th scope="col">{cohort.year}{cohort.year === 2026 && " post-adoption"}</th>)}</tr></thead>
       <tbody>
-        {deliveryMetrics.map((metric) => (
-          <tr>
-            <th scope="row">{metric.label}<span class="cell-detail">{metric.note}</span></th>
-            <td>{metric.before}</td>
-            <td>{metric.after}</td>
-          </tr>
-        ))}
+        <tr>
+          <th scope="row">All merged pull requests</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.allMergedPullRequests}</td>)}
+        </tr>
+        <tr>
+          <th scope="row">Non-dependency merged pull requests</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.nonDependencyMerges}</td>)}
+        </tr>
+        <tr>
+          <th scope="row">Published releases</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.releases}</td>)}
+        </tr>
+        <tr>
+          <th scope="row">Qualifying external product-defect reports</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.totalReports}</td>)}
+        </tr>
+        <tr>
+          <th scope="row">First introduced during window</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.introduced}</td>)}
+        </tr>
+        <tr>
+          <th scope="row">Median report-to-release</th>
+          {matchedWindowCohorts.map((cohort) => <td>{cohort.medianResponseDays === null ? "Not estimable" : `${cohort.medianResponseDays} ${cohort.medianResponseDays === 1 ? "day" : "days"}`}</td>)}
+        </tr>
       </tbody>
-    </table>
+      </table>
+    </div>
     <p>
-      Non-dependency merges increased from 15 to 281, or 18.7 times. The complete
-      2026 matched window contains 558 merges: 277 dependency-bot changes, 197
-      agent-authored changes, 80 maintainer-authored changes, and four changes by
-      other contributors. The 2025 matched window contains 153 merges: 138
-      dependency-bot changes, eleven maintainer-authored changes, and four changes
-      by other contributors.
+      The 2026 matched window has 281 non-dependency merges, compared with a
+      15–75 range across 2022–2025. Its 558 total merges include 277
+      dependency-bot changes, 197 agent-authored changes, 80 maintainer-authored
+      changes, and four changes by other contributors. The full historical range
+      remains visible because the immediately preceding 2025 cohort alone is not
+      a sufficient baseline.
     </p>
     <p>
       Authorship identifies provenance, not review effort or product value. A pull
@@ -107,24 +124,12 @@ const adoption = auditEvidence.activity.adoption;
     </p>
 
     <h2>Automated verification snapshots</h2>
-    <table class="research-table">
-      <thead><tr><th scope="col">Measure</th><th scope="col">Before adoption</th><th scope="col">September 3</th><th scope="col">Change during AI cohort</th></tr></thead>
-      <tbody>
-        {testingMetrics.map((metric) => (
-          <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td><td>{metric.displayChange}</td></tr>
-        ))}
-      </tbody>
-    </table>
-    <div class="table-scroll">
-      <table class="research-table">
-        <thead><tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Files added</th><th scope="col">Declarations, start → end</th><th scope="col">Declarations added</th></tr></thead>
-        <tbody>
-          {testCohortAdditions.map((cohort) => (
-            <tr><th scope="row">{cohort.label}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th><td>{cohort.displayTestFiles}</td><td>{cohort.displayTestFilesAdded}</td><td>{cohort.displayDeclarations}</td><td>{cohort.displayDeclarationsAdded}</td></tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <p>
+      The article’s single <a href="/quality/2026#verification-heading">five-year
+      verification table</a> provides the matched test-file, declaration, and
+      endpoint line-coverage observations for 2022–2026. Keeping the data in one
+      place avoids treating the 2025–2026 comparison as the only historical frame.
+    </p>
     <p>
       The file count includes JavaScript and TypeScript files containing at least
       one explicit <code>it</code> or <code>test</code> declaration, plus Python
@@ -134,13 +139,11 @@ const adoption = auditEvidence.activity.adoption;
       available in the repository and both invocations appear under Methods.
     </p>
     <p>
-      Public line coverage rose by 8.846 percentage points, from{" "}
-      <a href={auditEvidence.activity.snapshots.preAdoption.coverageSource}>82.884%</a>{" "}
-      immediately before adoption to{" "}
-      <a href={auditEvidence.activity.snapshots.endOfObservation.coverageSource}>91.73%</a>{" "}
-      at the observation endpoint. During that interval the project was reorganized
-      into multiple packages, so the percentages are real results over changing
-      source sets rather than a controlled measurement over identical files.
+      Public line coverage was 91.73% at the 2026 endpoint, following endpoint
+      observations of 92.065% (2022), 85.172% (2023), 82.599% (2024), and 84.260%
+      (2025). During the 2026 interval the project was reorganized into multiple
+      packages, so the percentages are real results over changing source sets
+      rather than a controlled measurement over identical files.
     </p>
 
     <h2>Commit and line-change activity</h2>
@@ -268,7 +271,9 @@ const adoption = auditEvidence.activity.adoption;
       {supplemental.publishedReleases["2026"]} releases in 2026. It used the final{" "}
       2025 release snapshot—{supplemental.testFiles["2025"]} test files and{" "}
       {supplemental.testDeclarations["2025"]} declarations—rather than the more
-      precise March 10 pre-adoption snapshot used in the article.
+      precise March 10 pre-adoption snapshot used in the article. This retained
+      two-year sensitivity check is not the report’s historical baseline: the
+      matched 2022–2025 cohorts are used for that purpose.
     </p>
 
     <h2>Public exposure did not contract</h2>

--- a/site/src/pages/quality/2026/context.astro
+++ b/site/src/pages/quality/2026/context.astro
@@ -141,9 +141,6 @@ const adoption = auditEvidence.activity.adoption;
     <p>
       Public branch coverage moved from 89.344% to 89.415% in 2026. The available
       earlier pairs are 94.432% to 91.746% (2023) and 90.683% to 89.856% (2024).
-      The 2025 start commit has no Coveralls build, but a local recomputation at
-      that exact commit measured 89.720% before the public 90.131% endpoint; the
-      unchanged historical suite retained one failing response-builder assertion.
       The 2022 cohort has no March start observation and ends at 95.513%. During
       the 2026 interval the project was reorganized into multiple packages, so the
       percentages are real results over changing source sets rather than a

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -50,10 +50,8 @@ const gitBaseline = Object.fromEntries(
           0, 6, and 1 files and 10, 48, and 6 declarations in the complete
           2023–2025 historical cohorts. Public branch coverage moved from 89.344%
           to 89.415% (+0.071 percentage points), while the two earlier complete
-          branch-coverage intervals declined by 2.686 and 0.827 points. The 2025
-          local recomputation moved from 89.720% to 90.131%, but its unchanged
-          historical suite retained one failing assertion; 2022 lacks a start
-          observation. Non-dependency delivery reached 281
+          branch-coverage intervals declined by 2.686 and 0.827 points; 2022
+          lacks a start observation. Non-dependency delivery reached 281
           merged pull requests, above the 15–75 range in 2022–2025. These
           observations are not a causal estimate. They do not establish that AI
           produced the improvement, and they do not measure unreported defects.
@@ -233,7 +231,7 @@ const gitBaseline = Object.fromEntries(
                 <td>{cohort.testDeclarations}</td>
                 <td>
                   {cohort.branchCoverageStart
-                    ? <><a href={cohort.branchCoverageStart.source}>{cohort.branchCoverageStart.branchCoveragePercent.toFixed(3)}%</a>{cohort.branchCoverageStart.sourceLabel && ` (${cohort.branchCoverageStart.sourceLabel})`} → </>
+                    ? <><a href={cohort.branchCoverageStart.source}>{cohort.branchCoverageStart.branchCoveragePercent.toFixed(3)}%</a>{cohort.branchCoverageStart.footnoteMarker && <sup aria-label="See table footnote">{cohort.branchCoverageStart.footnoteMarker}</sup>} → </>
                     : "Not available → "}
                   <a href={cohort.branchCoverageEnd.source}>{cohort.branchCoverageEnd.branchCoveragePercent.toFixed(3)}%</a>
                 </td>
@@ -243,12 +241,13 @@ const gitBaseline = Object.fromEntries(
         </table>
       </div>
       <p class="figure-note">
-        Coveralls values link to their public results. The 2025 start value links
-        to the exact commit because it is a locally recomputed observation, not a
-        Coveralls build; its cohort note records the non-green historical suite.
+        <sup>*</sup> Locally recomputed at the exact March start commit. It is not
+        a Coveralls build; the unchanged historical suite had one failing
+        response-builder assertion.
+      </p>
+      <p class="figure-note">
         The 2026 package reorganization changed the coverage denominator, so the
-        values are observations over changing source sets, not a fixed-codebase
-        experiment.
+        values are observations over changing source sets, not a fixed-codebase experiment.
       </p>
     </figure>
 

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -2,19 +2,12 @@
 import QualityLayout from "../../../layouts/QualityLayout.astro";
 import {
   auditEvidence,
-  comparisonSummary,
   gitHistoricalBaselineRows,
-  primaryComparisonSummary,
+  matchedWindowCohorts,
   retrospectiveBaselineRows,
-  testCohortAdditions,
-  testingMetrics,
+  verificationCohorts,
 } from "../../../data/quality-2026";
 
-const before = primaryComparisonSummary[0];
-const after = primaryComparisonSummary[1];
-const snapshots = auditEvidence.activity.snapshots;
-const fullBefore = comparisonSummary[0];
-const fullAfter = comparisonSummary[1];
 const historicalBaseline = Object.fromEntries(
   retrospectiveBaselineRows.map((row) => [row.label, row]),
 );
@@ -91,10 +84,9 @@ const gitBaseline = Object.fromEntries(
           preregistered experiment. The intervention begins at{" "}
           <a href={auditEvidence.study.intervention.source}>the first agent-authored
           product change merged to <code>main</code></a> on March 10, 2026. The
-          primary comparison uses the same March 10–September 3 interval in 2025.
-          Additional matched cohorts in 2022–2024 provide historical context, with
-          each measure using only years that have a complete comparable observation.
-          The broader January 1–September 3 cohorts remain as a sensitivity check.
+          primary comparison uses the same March 10–September 3 interval in each
+          year from 2022 through 2025. Each measure uses every historical year
+          with a complete comparable observation.
         </p>
         <p>
           The defect population contains public issues and accepted standalone
@@ -119,8 +111,9 @@ const gitBaseline = Object.fromEntries(
       <div class="figure-heading">
         <h2 id="primary-results">Results</h2>
         <p>
-          Table 1. Primary matched-window outcomes. The 2026 window begins at the
-          exact intervention timestamp; both windows end September 4 at 00:00 UTC.
+          Table 1. Matched-window outcomes across the four pre-AI historical
+          cohorts and the 2026 post-adoption cohort. Every window begins March 10
+          at 16:38:20 UTC and ends September 4 at 00:00 UTC.
         </p>
       </div>
       <div class="table-scroll">
@@ -128,40 +121,39 @@ const gitBaseline = Object.fromEntries(
           <thead>
             <tr>
               <th scope="col">Measure</th>
-              <th scope="col">2025 comparison</th>
-              <th scope="col">2026 post-adoption</th>
+              {matchedWindowCohorts.map((cohort) => (
+                <th scope="col">{cohort.year}{cohort.year === 2026 && " post-adoption"}</th>
+              ))}
             </tr>
           </thead>
           <tbody>
             <tr>
               <th scope="row">External product-defect reports</th>
-              <td>{before.totalReports}</td>
-              <td>{after.totalReports}</td>
+              {matchedWindowCohorts.map((cohort) => <td>{cohort.totalReports}</td>)}
             </tr>
             <tr>
               <th scope="row">First affected release entered during window</th>
-              <td>{before.introduced}</td>
-              <td>{after.introduced}</td>
+              {matchedWindowCohorts.map((cohort) => <td>{cohort.introduced}</td>)}
             </tr>
             <tr>
               <th scope="row">Introduced defects per 100 non-dependency merges</th>
-              <td>{before.introducedPer100Merges.toFixed(2)}</td>
-              <td>{after.introducedPer100Merges.toFixed(2)}</td>
+              {matchedWindowCohorts.map((cohort) => (
+                <td>{((cohort.introduced / cohort.nonDependencyMerges) * 100).toFixed(2)}</td>
+              ))}
             </tr>
             <tr>
               <th scope="row">Median report-to-release time</th>
-              <td>{before.medianResponseDays} days</td>
-              <td>{after.medianResponseDays} day</td>
+              {matchedWindowCohorts.map((cohort) => (
+                <td>{cohort.medianResponseDays === null ? "Not estimable" : `${cohort.medianResponseDays} ${cohort.medianResponseDays === 1 ? "day" : "days"}`}</td>
+              ))}
             </tr>
             <tr>
               <th scope="row">Non-dependency merged pull requests</th>
-              <td>{before.nonDependencyMerges}</td>
-              <td>{after.nonDependencyMerges}</td>
+              {matchedWindowCohorts.map((cohort) => <td>{cohort.nonDependencyMerges}</td>)}
             </tr>
             <tr>
               <th scope="row">Published releases</th>
-              <td>{before.releases}</td>
-              <td>{after.releases}</td>
+              {matchedWindowCohorts.map((cohort) => <td>{cohort.releases}</td>)}
             </tr>
           </tbody>
         </table>
@@ -178,13 +170,14 @@ const gitBaseline = Object.fromEntries(
         <h2 id="reported-versus-introduced">More reports, but none traced to the intervention period</h2>
         <p>
           External users reported seven confirmed product defects after adoption,
-          compared with three in the matched 2025 interval. That increase is
-          visible and should not be explained away. Source history changes its
-          interpretation, however: all seven post-adoption reports concerned
-          behavior already present before the first agent-authored change reached{" "}
-          <code>main</code>. Six were old edge cases. The seventh belonged to an
-          operation-ID feature first released on February 26, twelve days before
-          the intervention.
+          matching the highest count in the four 2022–2025 historical cohorts
+          (whose counts ranged from zero to seven). That increase from the
+          immediately preceding 2025 cohort is visible and should not be explained
+          away. Source history changes its interpretation, however: all seven
+          post-adoption reports concerned behavior already present before the first
+          agent-authored change reached <code>main</code>. Six were old edge cases.
+          The seventh belonged to an operation-ID feature first released on
+          February 26, twelve days before the intervention.
         </p>
         <p>
           The finding is therefore not “fewer bugs.” It is that the observed
@@ -199,10 +192,12 @@ const gitBaseline = Object.fromEntries(
         <h2 id="response-result">Corrections reached users faster</h2>
         <p>
           Median time from report to the first release containing the accepted
-          correction fell from six calendar days in the matched 2025 cohort to one
-          day after adoption. All seven post-adoption reports reached a corrected
-          release within five days. This measures release response, not the effort
-          required to diagnose, review, or test each correction.
+          correction was one day after adoption, below the five- to six-day
+          medians in the report-bearing 2023–2025 historical cohorts. (The 2022
+          cohort had no qualifying reports, so no median is estimable.) All seven
+          post-adoption reports reached a corrected release within five days. This
+          measures release response, not the effort required to diagnose, review,
+          or test each correction.
         </p>
       </section>
     </div>
@@ -211,67 +206,32 @@ const gitBaseline = Object.fromEntries(
       <figcaption class="figure-heading">
         <h2 id="verification-heading">Automated verification expanded</h2>
         <p>
-          Figure 1. Repository snapshots immediately before the first agent-authored
-          merge and at the September 3 observation point. The cohort table uses the
-          same March–September span in earlier years where repository history permits.
+          Table 2. Matched March–September verification snapshots for every
+          available cohort. The 2022 start snapshot is unavailable because the
+          repository’s reachable history begins after the March boundary.
         </p>
       </figcaption>
-      <div class="comparison-bars">
-        {
-          testingMetrics.map((metric) => (
-            <div class="comparison-measure">
-              <div class="comparison-label">
-                <strong>{metric.label}</strong>
-                <span>{metric.displayBefore} → {metric.displayAfter} ({metric.displayChange})</span>
-              </div>
-              <div class="comparison-row">
-                <span>Before</span>
-                <div class="bar-track">
-                  <div
-                    class="bar-fill bar-fill-before"
-                    style={`width: ${Math.max(4, (metric.before / metric.after) * 100)}%`}
-                  ></div>
-                </div>
-              </div>
-              <div class="comparison-row">
-                <span>After</span>
-                <div class="bar-track">
-                  <div class="bar-fill" style="width: 100%"></div>
-                </div>
-              </div>
-            </div>
-          ))
-        }
-      </div>
       <div class="table-scroll compact-table">
         <table class="research-table">
           <thead>
-            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Files added</th><th scope="col">Declarations, start → end</th><th scope="col">Declarations added</th></tr>
+            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Declarations, start → end</th><th scope="col">Reported line coverage at endpoint</th></tr>
           </thead>
           <tbody>
-            {testCohortAdditions.map((cohort) => (
-              <tr><th scope="row">{cohort.label}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th><td>{cohort.displayTestFiles}</td><td>{cohort.displayTestFilesAdded}</td><td>{cohort.displayDeclarations}</td><td>{cohort.displayDeclarationsAdded}</td></tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div class="table-scroll compact-table">
-        <table class="research-table">
-          <thead>
-            <tr><th scope="col">Measure</th><th scope="col">Before adoption</th><th scope="col">September 3</th><th scope="col">Change during AI cohort</th></tr>
-          </thead>
-          <tbody>
-            {testingMetrics.map((metric) => (
-              <tr><th scope="row">{metric.label}</th><td>{metric.displayBefore}</td><td>{metric.displayAfter}</td><td>{metric.displayChange}</td></tr>
+            {verificationCohorts.map((cohort) => (
+              <tr>
+                <th scope="row">{cohort.year}{cohort.year === 2026 && " AI cohort"}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th>
+                <td>{cohort.testFiles}</td>
+                <td>{cohort.testDeclarations}</td>
+                <td><a href={cohort.coverageSource}>{cohort.lineCoveragePercent.toFixed(3)}%</a></td>
+              </tr>
             ))}
           </tbody>
         </table>
       </div>
       <p class="figure-note">
-        Coverage sources:{" "}<a href={snapshots.preAdoption.coverageSource}>pre-adoption
-        build</a>{" "}and <a href={snapshots.endOfObservation.coverageSource}>September 3
-        build</a>. The 2026 package reorganization changed the coverage denominator;
-        the percentages are public results, not a fixed-codebase experiment.
+        Each percentage links to its public Coveralls result. The 2026 package
+        reorganization changed the coverage denominator, so the values are public
+        observations over changing source sets, not a fixed-codebase experiment.
       </p>
     </figure>
 
@@ -310,25 +270,6 @@ const gitBaseline = Object.fromEntries(
           <a href="/quality/2026/context">supplementary data</a> shows every cohort,
           historical range, churn category, coverage reference, and comparison
           with the benchmark.
-        </p>
-      </section>
-
-      <section aria-labelledby="sensitivity-heading">
-        <h2 id="sensitivity-heading">The broader audit gives the same origin pattern</h2>
-        <p>
-          The supplementary January 1–September 3 screen contains{" "}
-          {fullBefore.total} product defects in 2025 and {fullAfter.total} in 2026.
-          The 2026 set contains {fullAfter.preExisting} defects predating 2026 and{" "}
-          {fullAfter.featureDefects} defects born with a feature first released in
-          February 2026. It contains {fullAfter.regressions === 0 ? "no regressions" : `${fullAfter.regressions} regressions`} caused by a
-          2026 change. All fourteen cases meet the 90-day maturity threshold used
-          in the audit, so removing newer releases does not change those totals.
-        </p>
-        <p>
-          Three 2026 product records fall before the AI-adoption boundary. They
-          remain visible in the <a href="/quality/2026/cases">defect appendix</a>{" "}
-          and the <a href="/quality/2026/candidates">candidate ledger</a>, but they
-          are not used in the primary post-adoption comparison.
         </p>
       </section>
 

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -45,13 +45,16 @@ const gitBaseline = Object.fromEntries(
         <p>
           On the measures available, quality increased. The audit found no
           externally reported product defect whose first affected release entered
-          the post-adoption window. Median report-to-release time fell from six
-          days to one, test files increased from 36 to 72, explicit test
-          declarations from 270 to 904, and reported line coverage from 82.884%
-          to 91.73%, while non-dependency delivery increased from 15 to 281 merged
-          pull requests. These observations are not a causal estimate. They do
-          not establish that AI produced the improvement, and they do not measure
-          unreported defects.
+          the post-adoption window. In the matched 2026 period, 36 test files and
+          634 explicit test declarations were added, compared with additions of
+          0, 6, and 1 files and 10, 48, and 6 declarations in the complete
+          2023–2025 historical cohorts. Public branch coverage moved from 89.344%
+          to 89.415% (+0.071 percentage points), while the two earlier complete
+          branch-coverage intervals declined by 2.686 and 0.827 points; 2022 and
+          2025 lack a Coveralls start build. Non-dependency delivery reached 281
+          merged pull requests, above the 15–75 range in 2022–2025. These
+          observations are not a causal estimate. They do not establish that AI
+          produced the improvement, and they do not measure unreported defects.
         </p>
       </section>
     </header>
@@ -214,22 +217,31 @@ const gitBaseline = Object.fromEntries(
       <div class="table-scroll compact-table">
         <table class="research-table">
           <thead>
-            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Declarations, start → end</th><th scope="col">Reported line coverage at endpoint</th></tr>
+            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Declarations, start → end</th><th scope="col">Reported branch coverage, start → end</th></tr>
           </thead>
           <tbody>
             {verificationCohorts.map((cohort) => (
               <tr>
-                <th scope="row">{cohort.year}{cohort.year === 2026 && " AI cohort"}{cohort.note && <span class="cell-detail">{cohort.note}</span>}</th>
+                <th scope="row">
+                  {cohort.year}{cohort.year === 2026 && " AI cohort"}
+                  {cohort.note && <span class="cell-detail">{cohort.note}</span>}
+                  {cohort.firstReachableCommit && <span class="cell-detail">First main-reachable commit: <a href={`https://github.com/counterfact/api-simulator/commit/${cohort.firstReachableCommit}`}><code>{cohort.firstReachableCommit.slice(0, 8)}</code></a></span>}
+                </th>
                 <td>{cohort.testFiles}</td>
                 <td>{cohort.testDeclarations}</td>
-                <td><a href={cohort.coverageSource}>{cohort.lineCoveragePercent.toFixed(3)}%</a></td>
+                <td>
+                  {cohort.branchCoverageStart
+                    ? <><a href={cohort.branchCoverageStart.source}>{cohort.branchCoverageStart.branchCoveragePercent.toFixed(3)}%</a> → </>
+                    : "Not available → "}
+                  <a href={cohort.branchCoverageEnd.source}>{cohort.branchCoverageEnd.branchCoveragePercent.toFixed(3)}%</a>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
       <p class="figure-note">
-        Each percentage links to its public Coveralls result. The 2026 package
+        Each value links to its public Coveralls result. The 2026 package
         reorganization changed the coverage denominator, so the values are public
         observations over changing source sets, not a fixed-codebase experiment.
       </p>

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -50,8 +50,10 @@ const gitBaseline = Object.fromEntries(
           0, 6, and 1 files and 10, 48, and 6 declarations in the complete
           2023–2025 historical cohorts. Public branch coverage moved from 89.344%
           to 89.415% (+0.071 percentage points), while the two earlier complete
-          branch-coverage intervals declined by 2.686 and 0.827 points; 2022 and
-          2025 lack a Coveralls start build. Non-dependency delivery reached 281
+          branch-coverage intervals declined by 2.686 and 0.827 points. The 2025
+          local recomputation moved from 89.720% to 90.131%, but its unchanged
+          historical suite retained one failing assertion; 2022 lacks a start
+          observation. Non-dependency delivery reached 281
           merged pull requests, above the 15–75 range in 2022–2025. These
           observations are not a causal estimate. They do not establish that AI
           produced the improvement, and they do not measure unreported defects.
@@ -217,7 +219,7 @@ const gitBaseline = Object.fromEntries(
       <div class="table-scroll compact-table">
         <table class="research-table">
           <thead>
-            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Declarations, start → end</th><th scope="col">Reported branch coverage, start → end</th></tr>
+            <tr><th scope="col">Cohort</th><th scope="col">Test files, start → end</th><th scope="col">Declarations, start → end</th><th scope="col">Branch coverage, start → end</th></tr>
           </thead>
           <tbody>
             {verificationCohorts.map((cohort) => (
@@ -231,7 +233,7 @@ const gitBaseline = Object.fromEntries(
                 <td>{cohort.testDeclarations}</td>
                 <td>
                   {cohort.branchCoverageStart
-                    ? <><a href={cohort.branchCoverageStart.source}>{cohort.branchCoverageStart.branchCoveragePercent.toFixed(3)}%</a> → </>
+                    ? <><a href={cohort.branchCoverageStart.source}>{cohort.branchCoverageStart.branchCoveragePercent.toFixed(3)}%</a>{cohort.branchCoverageStart.sourceLabel && ` (${cohort.branchCoverageStart.sourceLabel})`} → </>
                     : "Not available → "}
                   <a href={cohort.branchCoverageEnd.source}>{cohort.branchCoverageEnd.branchCoveragePercent.toFixed(3)}%</a>
                 </td>
@@ -241,9 +243,12 @@ const gitBaseline = Object.fromEntries(
         </table>
       </div>
       <p class="figure-note">
-        Each value links to its public Coveralls result. The 2026 package
-        reorganization changed the coverage denominator, so the values are public
-        observations over changing source sets, not a fixed-codebase experiment.
+        Coveralls values link to their public results. The 2025 start value links
+        to the exact commit because it is a locally recomputed observation, not a
+        Coveralls build; its cohort note records the non-green historical suite.
+        The 2026 package reorganization changed the coverage denominator, so the
+        values are observations over changing source sets, not a fixed-codebase
+        experiment.
       </p>
     </figure>
 

--- a/site/src/pages/quality/2026/methodology.astro
+++ b/site/src/pages/quality/2026/methodology.astro
@@ -105,7 +105,7 @@ import { auditEvidence } from "../../../data/quality-2026";
         <strong>Automated verification.</strong> JavaScript and TypeScript files
         containing explicit <code>it</code>/<code>test</code> declarations, Python
         files named <code>test_*.py</code>, the number of those JavaScript and
-        TypeScript declarations, and the public Coveralls line-coverage result at
+        TypeScript declarations, and the public Coveralls branch-coverage result at
         the pre-adoption and end-of-observation snapshots.
       </li>
     </ol>

--- a/site/src/pages/quality/2026/methodology.astro
+++ b/site/src/pages/quality/2026/methodology.astro
@@ -105,8 +105,10 @@ import { auditEvidence } from "../../../data/quality-2026";
         <strong>Automated verification.</strong> JavaScript and TypeScript files
         containing explicit <code>it</code>/<code>test</code> declarations, Python
         files named <code>test_*.py</code>, the number of those JavaScript and
-        TypeScript declarations, and the public Coveralls branch-coverage result at
-        the pre-adoption and end-of-observation snapshots.
+        TypeScript declarations, and branch coverage at the pre-adoption and
+        end-of-observation snapshots. Values are public Coveralls results except
+        for the missing 2025 March result, which was locally recomputed at the
+        exact commit and is explicitly labelled with its non-green suite outcome.
       </li>
     </ol>
     <p>

--- a/site/src/pages/quality/2026/methodology.astro
+++ b/site/src/pages/quality/2026/methodology.astro
@@ -106,9 +106,7 @@ import { auditEvidence } from "../../../data/quality-2026";
         containing explicit <code>it</code>/<code>test</code> declarations, Python
         files named <code>test_*.py</code>, the number of those JavaScript and
         TypeScript declarations, and branch coverage at the pre-adoption and
-        end-of-observation snapshots. Values are public Coveralls results except
-        for the missing 2025 March result, which was locally recomputed at the
-        exact commit and is explicitly labelled with its non-green suite outcome.
+        end-of-observation snapshots.
       </li>
     </ol>
     <p>


### PR DESCRIPTION
## Summary

- Replace the two-point automated-verification presentation with one matched 2022–2026 table containing test files, test declarations, and branch coverage from start to end.
- Link the 2022 first main-reachable commit; record that 2022 has no starting observation; and use branch coverage consistently in the supporting data and method.
- Fill the missing 2025 start with an exact-commit local recomputation (89.720% branch coverage), indicated by an asterisk and a table footnote rather than repeated narrative callouts.
- Expand matched-window delivery and defect comparisons to the full 2022–2025 historical baseline; remove the January 1–September 3 sensitivity discussion from the main article.
- Update the abstract to quantify 2026 verification and delivery changes against the previous cohorts, with a regression check for all five coverage endpoints.

## Manual acceptance tests

- [x] Open the quality report and confirm the Automated verification expanded section has one table with 2022, 2023, 2024, 2025, and 2026 rows.
- [x] Confirm every row shows test-file and declaration start-to-end values plus branch-coverage start-to-end values, with linked sources.
- [x] Confirm the 2025 start is 89.720% with an asterisk linked to the exact March commit, and that the footnote below the table identifies it as a local recomputation rather than a Coveralls build.
- [x] Confirm the 2022 start remains unavailable and its first main-reachable commit is a clickable link.
- [x] Confirm the abstract quantifies 2026 test, declaration, branch-coverage, and delivery changes against the applicable earlier cohorts, and that the main article contains no January 1–September 3 sensitivity-cohort section.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: The change applies existing report-data and verification conventions; it did not expose reusable guidance missing from repository instructions.