### PR TITLE
Improve quality study presentation and accessibility

### DIFF
--- a/site/src/layouts/QualityLayout.astro
+++ b/site/src/layouts/QualityLayout.astro
@@ -38,6 +38,7 @@ const navItems = [
 ---
 
 <MainLayout title={title} description={description} canonicalPath={canonicalPath}>
+  <a class="quality-skip-link" href="#main-content">Skip to study content</a>
   <header class="quality-header">
     <div class="quality-reading quality-header-main">
       <a class="quality-brand" href="/" aria-label="Counterfact home">

--- a/site/src/pages/quality/2026/historical-candidates.astro
+++ b/site/src/pages/quality/2026/historical-candidates.astro
@@ -36,8 +36,8 @@ const years = [2022, 2023, 2024];
         return (
           <section aria-labelledby={`year-${year}`}>
             <h2 id={`year-${year}`}>{year}: {records.length} records, {included.length} included reports</h2>
-            <div class="table-scroll">
-              <table class="research-table">
+            <div class="table-scroll" tabindex="0" role="region" aria-label={`${year} candidate dispositions; scroll horizontally for all columns`}>
+              <table class="research-table wide-data-table historical-ledger-table">
                 <thead>
                   <tr>
                     <th scope="col">Record</th>

--- a/site/src/pages/quality/2026/index.astro
+++ b/site/src/pages/quality/2026/index.astro
@@ -22,6 +22,7 @@ const formatRate = (
   rate === null || interval === null
     ? "Not estimable"
     : `${(rate * scale).toFixed(2)} (95% exact CI ${(interval.lower * scale).toFixed(2)}–${(interval.upper * scale).toFixed(2)})`;
+const mature2026 = primaryMatureCohorts.find((cohort) => cohort.year === 2026)!;
 ---
 
 <QualityLayout
@@ -68,6 +69,41 @@ const formatRate = (
       </section>
     </header>
 
+    <section class="study-summary quality-figure-wide" aria-labelledby="summary-heading">
+      <div class="study-summary-copy">
+        <p class="eyebrow">At a glance</p>
+        <h2 id="summary-heading">Favorable observations, wide uncertainty</h2>
+        <p>
+          The mature 2026 cohort has no observed externally reported event across
+          14 releases and 235 non-dependency merges. That is compatible with a
+          favorable period, but exact intervals remain wide and this design
+          cannot observe silent or late reports.
+        </p>
+      </div>
+      <dl class="study-summary-grid">
+        <div>
+          <dt>Primary 2026 result</dt>
+          <dd><strong>{mature2026.events}</strong> mature events</dd>
+        </div>
+        <div>
+          <dt>Observed exposure</dt>
+          <dd><strong>{mature2026.nonDependencyMergedPullRequests}</strong> PRs · <strong>{mature2026.publishedReleases}</strong> releases</dd>
+        </div>
+        <div>
+          <dt>Correction response</dt>
+          <dd><strong>{mature2026.response.medianDays}</strong> day KM median · 7/7 resolved</dd>
+        </div>
+        <div>
+          <dt>Auditability</dt>
+          <dd><strong>567</strong> historical records published</dd>
+        </div>
+      </dl>
+      <p class="study-summary-verdict">
+        <strong>Interpretation:</strong> descriptive evidence only; causal AI
+        attribution is not estimable from this study.
+      </p>
+    </section>
+
     <div class="article-body quality-reading quality-prose">
       <section aria-labelledby="study-question">
         <h2 id="study-question">Research question</h2>
@@ -96,9 +132,10 @@ const formatRate = (
           preregistered experiment. The intervention begins at{" "}
           <a href={auditEvidence.study.intervention.source}>the first agent-authored
           product change merged to <code>main</code></a> on March 10, 2026. The
-          primary comparison uses the same March 10–September 3 interval in each
-          year from 2022 through 2025. Each measure uses every historical year
-          with a complete comparable observation.
+          defect comparison closes intake on June 6 so every release receives
+          exactly ninety days of follow-up. Verification and delivery context use
+          the longer matched March 10–September 3 interval. Each measure uses
+          every historical year with a complete comparable observation.
         </p>
         <p>
           The defect population contains public issues and accepted standalone
@@ -131,8 +168,19 @@ const formatRate = (
           primary. Rates are sensitivity analyses.
         </p>
       </div>
-      <div class="table-scroll">
-        <table class="research-table">
+      <div class="mature-event-chart" role="img" aria-label="Mature externally reported events by year: zero in 2023, three in 2024, zero in 2025, and zero in 2026.">
+        {primaryMatureCohorts.map((cohort) => (
+          <div class="mature-event-row">
+            <span>{cohort.year}</span>
+            <span class="mature-event-track" aria-hidden="true">
+              <span class:list={["mature-event-bar", { "is-zero": cohort.events === 0 }]} style={`--event-count: ${cohort.events}`}></span>
+            </span>
+            <strong>{cohort.events}</strong>
+          </div>
+        ))}
+      </div>
+      <div class="table-scroll" tabindex="0" role="region" aria-label="Ninety-day mature cohort results; scroll horizontally to see all years">
+        <table class="research-table wide-data-table">
           <thead>
             <tr>
               <th scope="col">Measure</th>

--- a/site/src/styles/quality.css
+++ b/site/src/styles/quality.css
@@ -16,6 +16,23 @@ body {
   color: var(--study-ink);
 }
 
+.quality-skip-link {
+  background: var(--study-ink);
+  color: #fff;
+  left: 1rem;
+  padding: 0.65rem 0.9rem;
+  position: fixed;
+  top: 0;
+  transform: translateY(-120%);
+  transition: transform 120ms ease;
+  z-index: 100;
+}
+
+.quality-skip-link:focus {
+  color: #fff;
+  transform: translateY(0.75rem);
+}
+
 .quality-reading {
   margin-inline: auto;
   width: min(100% - 2rem, 760px);
@@ -128,6 +145,69 @@ body {
   line-height: 1.7;
 }
 
+.study-summary {
+  background: #f1f5f6;
+  border: 1px solid #cbd5d9;
+  margin-block: 3rem 4rem;
+  padding: clamp(1.25rem, 4vw, 2rem);
+}
+
+.study-summary-copy {
+  max-width: 720px;
+}
+
+.study-summary h2 {
+  font-family: var(--study-serif);
+  font-size: clamp(1.65rem, 4vw, 2.3rem);
+  line-height: 1.1;
+  margin: 0 0 0.75rem;
+}
+
+.study-summary-copy > p:last-child,
+.study-summary-verdict {
+  color: #34414b;
+  line-height: 1.65;
+}
+
+.study-summary-grid {
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 1.5rem 0 0;
+}
+
+.study-summary-grid div {
+  background: var(--study-paper);
+  border: 1px solid var(--study-rule);
+  margin-left: -1px;
+  padding: 1rem;
+}
+
+.study-summary-grid dt {
+  color: var(--study-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.study-summary-grid dd {
+  font-size: 0.92rem;
+  line-height: 1.45;
+  margin: 0.4rem 0 0;
+}
+
+.study-summary-grid dd strong {
+  color: var(--study-ink);
+  font-size: 1.2rem;
+}
+
+.study-summary-verdict {
+  border-top: 1px solid #cbd5d9;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+}
+
 .article-body {
   font-family: var(--study-serif);
   font-size: 1.06rem;
@@ -216,7 +296,14 @@ body {
 
 .table-scroll {
   max-width: 100%;
+  overscroll-behavior-inline: contain;
   overflow-x: auto;
+  scrollbar-color: var(--study-before) transparent;
+}
+
+.table-scroll:focus-visible {
+  outline: 3px solid var(--orange);
+  outline-offset: 4px;
 }
 
 .research-table {
@@ -252,6 +339,45 @@ body {
 
 .compact-table {
   margin-top: 1.6rem;
+}
+
+.mature-event-chart {
+  display: grid;
+  gap: 0.65rem;
+  margin: 1.5rem 0;
+  max-width: 620px;
+}
+
+.mature-event-row {
+  align-items: center;
+  display: grid;
+  font: 0.84rem/1 var(--font-sans);
+  gap: 0.75rem;
+  grid-template-columns: 3.2rem minmax(8rem, 1fr) 1.5rem;
+}
+
+.mature-event-track {
+  align-items: center;
+  background: #e1e6e7;
+  display: flex;
+  height: 0.72rem;
+}
+
+.mature-event-bar {
+  background: var(--study-after);
+  display: block;
+  height: 100%;
+  min-width: 0;
+  width: calc(var(--event-count) / 3 * 100%);
+}
+
+.mature-event-bar.is-zero {
+  background: var(--study-muted);
+  border-radius: 50%;
+  height: 0.55rem;
+  min-width: 0.55rem;
+  transform: translateX(0.1rem);
+  width: 0.55rem;
 }
 
 .comparison-bars {
@@ -511,6 +637,27 @@ body {
 }
 
 @media (max-width: 700px) {
+  .study-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .wide-data-table {
+    min-width: 760px;
+  }
+
+  .wide-data-table th:first-child {
+    background: var(--study-paper);
+    box-shadow: 1px 0 0 var(--study-rule);
+    left: 0;
+    position: sticky;
+    z-index: 1;
+  }
+
+  .wide-data-table thead th:first-child {
+    background: var(--study-figure);
+    z-index: 2;
+  }
+
   .definition-list,
   .case-facts {
     grid-template-columns: 1fr;
@@ -526,6 +673,10 @@ body {
 }
 
 @media (max-width: 480px) {
+  .study-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
   .quality-nav-inner {
     gap: 0.9rem;
   }
@@ -546,6 +697,12 @@ body {
 
   .case-pagination a {
     max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quality-skip-link {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary

This is pull request 3 of 3 and depends on #2399.

- add an at-a-glance section that foregrounds the primary result, observed exposure, correction response, auditability, and causal limitation
- add an accessible mature-event chart with an equivalent text description
- make wide result and ledger tables independently scrollable and keyboard-focusable with sticky first columns on narrow screens
- add a skip link, responsive summary cards, and reduced-motion handling

## Verification

- `npm --prefix site run test:audit` — 22 tests passed
- `npm --prefix site run verify:audit`
- `npm --prefix site run build` — 96 pages built
- `git diff --check`
- desktop and 390-pixel mobile browser inspection

## Manual acceptance tests

- [x] Confirm the desktop At a glance section makes the primary result and causal caveat easy to find.
- [x] Confirm the summary cards stack cleanly on a narrow mobile viewport without causing page-level horizontal overflow.
- [x] Confirm the wide result and ledger tables scroll inside labeled keyboard-focusable regions.
- [x] Confirm the skip link becomes visible when focused and targets the main study content.
- [x] Confirm the mature-event chart communicates the sequence 0, 3, 0, 0 through accessible text as well as visual bars.

## Repository learning check

- Learning found: No
- Guidance updated: No
- Updated file(s): N/A
- Rationale: This stage follows existing responsive-design and accessibility patterns and did not reveal a new repository-wide rule.
